### PR TITLE
[PY] v0.6.6 only cancel Short-Term orders, break stateful order cancellations

### DIFF
--- a/v4-client-py/pyproject.toml
+++ b/v4-client-py/pyproject.toml
@@ -5,7 +5,7 @@ package-dir = {"" = "v4_client_py"}
 
 [tool.poetry]
 name = "v4-client-py"
-version = "0.6.5"
+version = "0.6.6"
 description = "dYdX v4 Client"
 authors = ["John Huang <contact@dydx.exchange>"]
 license = "BSL-1.1"

--- a/v4-client-py/v4_client_py/clients/composer.py
+++ b/v4-client-py/v4_client_py/clients/composer.py
@@ -155,8 +155,7 @@ class Composer:
         )
         return MsgCancelOrder(
             order_id=order_id, 
-            good_til_block=good_til_block,
-            good_til_block_time=good_til_block_time
+            good_til_block=good_til_block
         )
     
     def compose_msg_transfer(


### PR DESCRIPTION
This is a quick hack to get MM testnet onboarding unblocked. This should be fine since the Python client is not used by the frontend, and therefore doesn't send stateful order cancellations.

[Slack thread for context](https://dydx-team.slack.com/archives/C05S4CTSQ74/p1695218524347379?thread_ts=1695071666.623229&cid=C05S4CTSQ74).