### PR TITLE
Rename Subaccount to SubaccountInfo

### DIFF
--- a/v4-client-js/__tests__/modules/client/Transfers.test.ts
+++ b/v4-client-js/__tests__/modules/client/Transfers.test.ts
@@ -1,6 +1,6 @@
 import { Network } from '../../../src/clients/constants';
 import LocalWallet from '../../../src/clients/modules/local-wallet';
-import { Subaccount } from '../../../src/clients/subaccount';
+import { SubaccountInfo } from '../../../src/clients/subaccount';
 import { ValidatorClient } from '../../../src/clients/validator-client';
 import { DYDX_TEST_MNEMONIC } from '../../../examples/constants';
 import Long from 'long';
@@ -12,13 +12,13 @@ async function sleep(ms: number): Promise<void> {
 
 describe('Validator Client', () => {
   let wallet: LocalWallet;
-  let subaccount: Subaccount;
+  let subaccount: SubaccountInfo;
   let client: ValidatorClient;
 
   describe('Transfers', () => {
     beforeEach(async () => {
       wallet = await LocalWallet.fromMnemonic(DYDX_TEST_MNEMONIC, BECH32_PREFIX);
-      subaccount = new Subaccount(wallet, 0);
+      subaccount = new SubaccountInfo(wallet, 0);
       client = await ValidatorClient.connect(Network.testnet().validatorConfig);
       await sleep(5000);  // wait for withdraw to complete
     });

--- a/v4-client-js/__tests__/modules/client/ValidatorPostEndpoints.test.ts
+++ b/v4-client-js/__tests__/modules/client/ValidatorPostEndpoints.test.ts
@@ -2,7 +2,7 @@ import { Order_Side } from '@dydxprotocol/v4-proto/src/codegen/dydxprotocol/clob
 
 import { Network } from '../../../src/clients/constants';
 import LocalWallet from '../../../src/clients/modules/local-wallet';
-import { Subaccount } from '../../../src/clients/subaccount';
+import { SubaccountInfo } from '../../../src/clients/subaccount';
 import { IPlaceOrder } from '../../../src/clients/types';
 import { ValidatorClient } from '../../../src/clients/validator-client';
 import { randomInt } from '../../../src/lib/utils';
@@ -41,7 +41,7 @@ describe('Validator Client', () => {
       console.log('**Account**');
       console.log(account);
       const height = await client.get.latestBlockHeight();
-      const subaccount = new Subaccount(wallet, 0);
+      const subaccount = new SubaccountInfo(wallet, 0);
       const placeOrder = dummyOrder(height);
       placeOrder.clientId = randomInt(1_000_000_000);
       const tx = await client.post.placeOrderObject(

--- a/v4-client-js/examples/composite_example.ts
+++ b/v4-client-js/examples/composite_example.ts
@@ -4,7 +4,7 @@ import {
   Network, OrderExecution, OrderSide, OrderTimeInForce, OrderType,
 } from '../src/clients/constants';
 import LocalWallet from '../src/clients/modules/local-wallet';
-import { Subaccount } from '../src/clients/subaccount';
+import { SubaccountInfo } from '../src/clients/subaccount';
 import { randomInt } from '../src/lib/utils';
 import { DYDX_TEST_MNEMONIC, MAX_CLIENT_ID } from './constants';
 import ordersParams from './human_readable_orders.json';
@@ -20,7 +20,7 @@ async function test(): Promise<void> {
   const client = await CompositeClient.connect(network);
   console.log('**Client**');
   console.log(client);
-  const subaccount = new Subaccount(wallet, 0);
+  const subaccount = new SubaccountInfo(wallet, 0);
   for (const orderParams of ordersParams) {
     try {
       const type = OrderType[orderParams.type as keyof typeof OrderType];

--- a/v4-client-js/examples/long_term_order_cancel_example.ts
+++ b/v4-client-js/examples/long_term_order_cancel_example.ts
@@ -4,7 +4,7 @@ import {
   Network, OrderExecution, OrderSide, OrderTimeInForce, OrderType,
 } from '../src/clients/constants';
 import LocalWallet from '../src/clients/modules/local-wallet';
-import { Subaccount } from '../src/clients/subaccount';
+import { SubaccountInfo } from '../src/clients/subaccount';
 import { randomInt } from '../src/lib/utils';
 import { DYDX_TEST_MNEMONIC, MAX_CLIENT_ID } from './constants';
 
@@ -19,7 +19,7 @@ async function test(): Promise<void> {
   const client = await CompositeClient.connect(network);
   console.log('**Client**');
   console.log(client);
-  const subaccount = new Subaccount(wallet, 0);
+  const subaccount = new SubaccountInfo(wallet, 0);
 
   /*
   Note this example places a stateful order.

--- a/v4-client-js/examples/short_term_order_cancel_example.ts
+++ b/v4-client-js/examples/short_term_order_cancel_example.ts
@@ -4,7 +4,7 @@ import {
   Network, OrderSide,
 } from '../src/clients/constants';
 import LocalWallet from '../src/clients/modules/local-wallet';
-import { Subaccount } from '../src/clients/subaccount';
+import { SubaccountInfo } from '../src/clients/subaccount';
 import { randomInt, sleep } from '../src/lib/utils';
 import { DYDX_TEST_MNEMONIC, MAX_CLIENT_ID } from './constants';
 
@@ -15,7 +15,7 @@ async function test(): Promise<void> {
   const client = await CompositeClient.connect(network);
   console.log('**Client**');
   console.log(client);
-  const subaccount = new Subaccount(wallet, 0);
+  const subaccount = new SubaccountInfo(wallet, 0);
 
   const currentBlock = await client.validatorClient.get.latestBlockHeight();
   const nextValidBlockHeight = currentBlock + 1;

--- a/v4-client-js/examples/short_term_order_composite_example.ts
+++ b/v4-client-js/examples/short_term_order_composite_example.ts
@@ -6,7 +6,7 @@ import {
   Network, OrderExecution, OrderSide,
 } from '../src/clients/constants';
 import LocalWallet from '../src/clients/modules/local-wallet';
-import { Subaccount } from '../src/clients/subaccount';
+import { SubaccountInfo } from '../src/clients/subaccount';
 import { randomInt } from '../src/lib/utils';
 import { DYDX_TEST_MNEMONIC } from './constants';
 import ordersParams from './human_readable_short_term_orders.json';
@@ -22,7 +22,7 @@ async function test(): Promise<void> {
   const client = await CompositeClient.connect(network);
   console.log('**Client**');
   console.log(client);
-  const subaccount = new Subaccount(wallet, 0);
+  const subaccount = new SubaccountInfo(wallet, 0);
   for (const orderParams of ordersParams) {
     try {
       const side = OrderSide[orderParams.side as keyof typeof OrderSide];

--- a/v4-client-js/examples/test.ts
+++ b/v4-client-js/examples/test.ts
@@ -4,7 +4,7 @@ import {
   Network, OrderExecution, OrderSide, OrderTimeInForce, OrderType,
 } from '../src/clients/constants';
 import LocalWallet from '../src/clients/modules/local-wallet';
-import { Subaccount } from '../src/clients/subaccount';
+import { SubaccountInfo } from '../src/clients/subaccount';
 import { randomInt } from '../src/lib/utils';
 import { DYDX_TEST_MNEMONIC, MAX_CLIENT_ID } from './constants';
 import ordersParams from './human_readable_orders.json';
@@ -20,7 +20,7 @@ async function test(): Promise<void> {
   const client = await CompositeClient.connect(network);
   console.log('**Client**');
   console.log(client);
-  const subaccount = new Subaccount(wallet, 0);
+  const subaccount = new SubaccountInfo(wallet, 0);
   for (const orderParams of ordersParams) {
     try {
       const type = OrderType[orderParams.type as keyof typeof OrderType];

--- a/v4-client-js/examples/transfer_example_deposit.ts
+++ b/v4-client-js/examples/transfer_example_deposit.ts
@@ -3,7 +3,7 @@ import Long from 'long';
 import { BECH32_PREFIX } from '../src';
 import { Network } from '../src/clients/constants';
 import LocalWallet from '../src/clients/modules/local-wallet';
-import { Subaccount } from '../src/clients/subaccount';
+import { SubaccountInfo } from '../src/clients/subaccount';
 import { ValidatorClient } from '../src/clients/validator-client';
 import { DYDX_TEST_MNEMONIC } from './constants';
 
@@ -15,7 +15,7 @@ async function test(): Promise<void> {
   console.log('**Client**');
   console.log(client);
 
-  const subaccount = new Subaccount(wallet, 0);
+  const subaccount = new SubaccountInfo(wallet, 0);
   const tx = await client.post.deposit(
     subaccount,
     0,

--- a/v4-client-js/examples/transfer_example_send.ts
+++ b/v4-client-js/examples/transfer_example_send.ts
@@ -6,7 +6,7 @@ import { TEST_RECIPIENT_ADDRESS } from '../__tests__/helpers/constants';
 import { BECH32_PREFIX } from '../src';
 import { Network } from '../src/clients/constants';
 import LocalWallet from '../src/clients/modules/local-wallet';
-import { Subaccount } from '../src/clients/subaccount';
+import { SubaccountInfo } from '../src/clients/subaccount';
 import { ValidatorClient } from '../src/clients/validator-client';
 import { DYDX_TEST_MNEMONIC } from './constants';
 
@@ -21,7 +21,7 @@ async function test(): Promise<void> {
   console.log('**Client**');
   console.log(client);
 
-  const subaccount = new Subaccount(wallet, 0);
+  const subaccount = new SubaccountInfo(wallet, 0);
 
   const amount = new Long(100_000_000);
 

--- a/v4-client-js/examples/transfer_example_subaccount_transfer.ts
+++ b/v4-client-js/examples/transfer_example_subaccount_transfer.ts
@@ -3,7 +3,7 @@ import Long from 'long';
 import { BECH32_PREFIX } from '../src';
 import { Network } from '../src/clients/constants';
 import LocalWallet from '../src/clients/modules/local-wallet';
-import { Subaccount } from '../src/clients/subaccount';
+import { SubaccountInfo } from '../src/clients/subaccount';
 import { ValidatorClient } from '../src/clients/validator-client';
 import { DYDX_TEST_MNEMONIC } from './constants';
 
@@ -15,7 +15,7 @@ async function test(): Promise<void> {
   console.log('**Client**');
   console.log(client);
 
-  const subaccount = new Subaccount(wallet, 0);
+  const subaccount = new SubaccountInfo(wallet, 0);
 
   const tx = await client.post.transfer(
     subaccount,

--- a/v4-client-js/examples/transfer_example_withdraw.ts
+++ b/v4-client-js/examples/transfer_example_withdraw.ts
@@ -3,7 +3,7 @@ import Long from 'long';
 import { BECH32_PREFIX } from '../src';
 import { Network } from '../src/clients/constants';
 import LocalWallet from '../src/clients/modules/local-wallet';
-import { Subaccount } from '../src/clients/subaccount';
+import { SubaccountInfo } from '../src/clients/subaccount';
 import { ValidatorClient } from '../src/clients/validator-client';
 import { DYDX_TEST_MNEMONIC } from './constants';
 
@@ -17,7 +17,7 @@ async function test(): Promise<void> {
   console.log('**Client**');
   console.log(client);
 
-  const subaccount = new Subaccount(wallet, 0);
+  const subaccount = new SubaccountInfo(wallet, 0);
 
   const tx = await client.post.withdraw(
     subaccount,

--- a/v4-client-js/examples/transfer_example_withdraw_other.ts
+++ b/v4-client-js/examples/transfer_example_withdraw_other.ts
@@ -6,7 +6,7 @@ import { TEST_RECIPIENT_ADDRESS } from '../__tests__/helpers/constants';
 import { BECH32_PREFIX } from '../src';
 import { Network } from '../src/clients/constants';
 import LocalWallet from '../src/clients/modules/local-wallet';
-import { Subaccount } from '../src/clients/subaccount';
+import { SubaccountInfo } from '../src/clients/subaccount';
 import { ValidatorClient } from '../src/clients/validator-client';
 import { DYDX_TEST_MNEMONIC } from './constants';
 
@@ -18,7 +18,7 @@ async function test(): Promise<void> {
   console.log('**Client**');
   console.log(client);
 
-  const subaccount = new Subaccount(wallet, 0);
+  const subaccount = new SubaccountInfo(wallet, 0);
 
   const amount = new Long(100_000_000);
 

--- a/v4-client-js/examples/validator_post_example.ts
+++ b/v4-client-js/examples/validator_post_example.ts
@@ -4,7 +4,7 @@ import protobuf from 'protobufjs';
 import { BECH32_PREFIX } from '../src';
 import { Network } from '../src/clients/constants';
 import LocalWallet from '../src/clients/modules/local-wallet';
-import { Subaccount } from '../src/clients/subaccount';
+import { SubaccountInfo } from '../src/clients/subaccount';
 import { IPlaceOrder } from '../src/clients/types';
 import { ValidatorClient } from '../src/clients/validator-client';
 import { randomInt } from '../src/lib/utils';
@@ -40,7 +40,7 @@ async function test(): Promise<void> {
   const value1 = Long.fromNumber(400000000000);
   console.log(value1.toString());
 
-  const subaccount = new Subaccount(wallet, 0);
+  const subaccount = new SubaccountInfo(wallet, 0);
   for (const orderParams of ordersParams) {
     const height = await client.get.latestBlockHeight();
     const placeOrder = dummyOrder(height);

--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.30.1",

--- a/v4-client-js/src/clients/composite-client.ts
+++ b/v4-client-js/src/clients/composite-client.ts
@@ -32,7 +32,7 @@ import {
 import { IndexerClient } from './indexer-client';
 import { UserError } from './lib/errors';
 import LocalWallet from './modules/local-wallet';
-import { Subaccount } from './subaccount';
+import { SubaccountInfo } from './subaccount';
 import { ValidatorClient } from './validator-client';
 
 // Required for encoding and decoding queries that are of type Long.
@@ -268,7 +268,7 @@ export class CompositeClient {
    * @returns The transaction hash.
    */
   async placeShortTermOrder(
-    subaccount: Subaccount,
+    subaccount: SubaccountInfo,
     marketId: string,
     side: OrderSide,
     price: number,
@@ -340,7 +340,7 @@ export class CompositeClient {
      * @returns The transaction hash.
      */
   async placeOrder(
-    subaccount: Subaccount,
+    subaccount: SubaccountInfo,
     marketId: string,
     type: OrderType,
     side: OrderSide,
@@ -420,7 +420,7 @@ export class CompositeClient {
      * @returns The message to be passed into the protocol
      */
   private async placeOrderMessage(
-    subaccount: Subaccount,
+    subaccount: SubaccountInfo,
     marketId: string,
     type: OrderType,
     side: OrderSide,
@@ -541,7 +541,7 @@ export class CompositeClient {
      * @returns The message to be passed into the protocol
      */
   private async placeShortTermOrderMessage(
-    subaccount: Subaccount,
+    subaccount: SubaccountInfo,
     marketId: string,
     side: OrderSide,
     price: number,
@@ -607,7 +607,7 @@ export class CompositeClient {
      * @returns The transaction hash.
      */
   async cancelRawOrder(
-    subaccount: Subaccount,
+    subaccount: SubaccountInfo,
     clientId: number,
     orderFlags: OrderFlags,
     clobPairId: number,
@@ -639,7 +639,7 @@ export class CompositeClient {
      * @returns The transaction hash.
      */
   async cancelOrder(
-    subaccount: Subaccount,
+    subaccount: SubaccountInfo,
     clientId: number,
     orderFlags: OrderFlags,
     marketId: string,
@@ -699,7 +699,7 @@ export class CompositeClient {
      * @returns The transaction hash.
      */
   async transferToSubaccount(
-    subaccount: Subaccount,
+    subaccount: SubaccountInfo,
     recipientAddress: string,
     recipientSubaccountNumber: number,
     amount: string,
@@ -733,7 +733,7 @@ export class CompositeClient {
      * @returns The message
      */
   transferToSubaccountMessage(
-    subaccount: Subaccount,
+    subaccount: SubaccountInfo,
     recipientAddress: string,
     recipientSubaccountNumber: number,
     amount: string,
@@ -771,7 +771,7 @@ export class CompositeClient {
      * @returns The transaction hash.
      */
   async depositToSubaccount(
-    subaccount: Subaccount,
+    subaccount: SubaccountInfo,
     amount: string,
   ): Promise<BroadcastTxAsyncResponse | BroadcastTxSyncResponse | IndexedTx> {
     const msgs: Promise<EncodeObject[]> = new Promise((resolve) => {
@@ -797,7 +797,7 @@ export class CompositeClient {
      * @returns The message
      */
   depositToSubaccountMessage(
-    subaccount: Subaccount,
+    subaccount: SubaccountInfo,
     amount: string,
   ): EncodeObject {
     const validatorClient = this._validatorClient;
@@ -832,7 +832,7 @@ export class CompositeClient {
      * @returns The transaction hash
      */
   async withdrawFromSubaccount(
-    subaccount: Subaccount,
+    subaccount: SubaccountInfo,
     amount: string,
     recipient?: string,
   ): Promise<BroadcastTxAsyncResponse | BroadcastTxSyncResponse | IndexedTx> {
@@ -863,7 +863,7 @@ export class CompositeClient {
      * @returns The message
      */
   withdrawFromSubaccountMessage(
-    subaccount: Subaccount,
+    subaccount: SubaccountInfo,
     amount: string,
     recipient?: string,
   ): EncodeObject {
@@ -929,7 +929,7 @@ export class CompositeClient {
   }
 
   async signPlaceOrder(
-    subaccount: Subaccount,
+    subaccount: SubaccountInfo,
     marketId: string,
     type: OrderType,
     side: OrderSide,
@@ -973,7 +973,7 @@ export class CompositeClient {
   }
 
   async signCancelOrder(
-    subaccount: Subaccount,
+    subaccount: SubaccountInfo,
     clientId: number,
     orderFlags: OrderFlags,
     clobPairId: number,

--- a/v4-client-js/src/clients/modules/post.ts
+++ b/v4-client-js/src/clients/modules/post.ts
@@ -25,7 +25,7 @@ import protobuf from 'protobufjs';
 import { GAS_MULTIPLIER } from '../constants';
 import { UnexpectedClientError } from '../lib/errors';
 import { generateRegistry } from '../lib/registry';
-import { Subaccount } from '../subaccount';
+import { SubaccountInfo } from '../subaccount';
 import {
   OrderFlags,
   BroadcastMode,
@@ -343,7 +343,7 @@ export class Post {
     // ------ State-Changing Requests ------ //
 
     async placeOrder(
-      subaccount: Subaccount,
+      subaccount: SubaccountInfo,
       clientId: number,
       clobPairId: number,
       side: Order_Side,
@@ -392,7 +392,7 @@ export class Post {
     }
 
     async placeOrderObject(
-      subaccount: Subaccount,
+      subaccount: SubaccountInfo,
       placeOrder: IPlaceOrder,
       broadcastMode?: BroadcastMode,
     ): Promise<BroadcastTxAsyncResponse | BroadcastTxSyncResponse | IndexedTx> {
@@ -416,7 +416,7 @@ export class Post {
     }
 
     async cancelOrder(
-      subaccount: Subaccount,
+      subaccount: SubaccountInfo,
       clientId: number,
       orderFlags: OrderFlags,
       clobPairId: number,
@@ -446,7 +446,7 @@ export class Post {
     }
 
     async cancelOrderObject(
-      subaccount: Subaccount,
+      subaccount: SubaccountInfo,
       cancelOrder: ICancelOrder,
       broadcastMode?: BroadcastMode,
     ): Promise<BroadcastTxAsyncResponse | BroadcastTxSyncResponse | IndexedTx> {
@@ -462,7 +462,7 @@ export class Post {
     }
 
     async transfer(
-      subaccount: Subaccount,
+      subaccount: SubaccountInfo,
       recipientAddress: string,
       recipientSubaccountNumber: number,
       assetId: number,
@@ -491,7 +491,7 @@ export class Post {
     }
 
     async deposit(
-      subaccount: Subaccount,
+      subaccount: SubaccountInfo,
       assetId: number,
       quantums: Long,
       broadcastMode?: BroadcastMode,
@@ -516,7 +516,7 @@ export class Post {
     }
 
     async withdraw(
-      subaccount: Subaccount,
+      subaccount: SubaccountInfo,
       assetId: number,
       quantums: Long,
       recipient?: string,
@@ -543,7 +543,7 @@ export class Post {
     }
 
     async sendToken(
-      subaccount: Subaccount,
+      subaccount: SubaccountInfo,
       recipient: string,
       coinDenom: string,
       quantums: string,

--- a/v4-client-js/src/clients/native.ts
+++ b/v4-client-js/src/clients/native.ts
@@ -19,7 +19,7 @@ import {
 } from './constants';
 import { FaucetClient } from './faucet-client';
 import LocalWallet from './modules/local-wallet';
-import { Subaccount } from './subaccount';
+import { SubaccountInfo } from './subaccount';
 import { OrderFlags } from './types';
 
 declare global {
@@ -252,7 +252,7 @@ export async function placeOrder(
     const marketInfo = json.marketInfo as MarketInfo;
     const currentHeight = json.currentHeight as number;
 
-    const subaccount = new Subaccount(wallet, subaccountNumber);
+    const subaccount = new SubaccountInfo(wallet, subaccountNumber);
     const tx = await client.placeOrder(
       subaccount,
       marketId,
@@ -314,7 +314,7 @@ export async function cancelOrder(
     const goodTilBlock = json.goodTilBlock;
     const goodTilBlockTime = json.goodTilBlockTime;
 
-    const subaccount = new Subaccount(wallet, subaccountNumber);
+    const subaccount = new SubaccountInfo(wallet, subaccountNumber);
     const tx = await client.cancelRawOrder(
       subaccount,
       clientId,
@@ -352,7 +352,7 @@ export async function deposit(
       throw new UserError('amount is not set');
     }
 
-    const subaccount = new Subaccount(wallet, subaccountNumber);
+    const subaccount = new SubaccountInfo(wallet, subaccountNumber);
     const tx = await client.depositToSubaccount(
       subaccount,
       amount,
@@ -386,7 +386,7 @@ export async function withdraw(
       throw new UserError('amount is not set');
     }
 
-    const subaccount = new Subaccount(wallet, subaccountNumber);
+    const subaccount = new SubaccountInfo(wallet, subaccountNumber);
     const tx = await client.withdrawFromSubaccount(
       subaccount,
       amount,
@@ -454,7 +454,7 @@ export async function withdrawToIBC(
       value: json.msg,
     };
 
-    const subaccount = new Subaccount(wallet, subaccountNumber);
+    const subaccount = new SubaccountInfo(wallet, subaccountNumber);
     const subaccountMsg = client.withdrawFromSubaccountMessage(subaccount, amount);
 
     const msgs = [subaccountMsg, ibcMsg];
@@ -597,7 +597,7 @@ export async function simulateDeposit(
       throw new UserError('amount is not set');
     }
 
-    const subaccount = new Subaccount(wallet, subaccountNumber);
+    const subaccount = new SubaccountInfo(wallet, subaccountNumber);
     const msg: EncodeObject = client.depositToSubaccountMessage(
       subaccount,
       amount,
@@ -639,7 +639,7 @@ export async function simulateWithdraw(
       throw new UserError('amount is not set');
     }
 
-    const subaccount = new Subaccount(wallet, subaccountNumber);
+    const subaccount = new SubaccountInfo(wallet, subaccountNumber);
     const msg: EncodeObject = client.withdrawFromSubaccountMessage(
       subaccount,
       amount,
@@ -780,7 +780,7 @@ export async function signPlaceOrder(
       throw new UserError('wallet is not set. Call connectWallet() first');
     }
 
-    const subaccount = new Subaccount(wallet, subaccountNumber);
+    const subaccount = new SubaccountInfo(wallet, subaccountNumber);
     const signed = await client.signPlaceOrder(
       subaccount,
       marketId,
@@ -819,7 +819,7 @@ export async function signCancelOrder(
       throw new UserError('wallet is not set. Call connectWallet() first');
     }
 
-    const subaccount = new Subaccount(wallet, subaccountNumber);
+    const subaccount = new SubaccountInfo(wallet, subaccountNumber);
     const signed = await client.signCancelOrder(
       subaccount,
       clientId,

--- a/v4-client-js/src/clients/subaccount.ts
+++ b/v4-client-js/src/clients/subaccount.ts
@@ -1,6 +1,6 @@
 import LocalWallet from './modules/local-wallet';
 
-export class Subaccount {
+export class SubaccountInfo {
     readonly wallet: LocalWallet;
     // TODO, change address to Wallet object when implementing validator functions
     readonly subaccountNumber: number;

--- a/v4-client-js/src/index.ts
+++ b/v4-client-js/src/index.ts
@@ -7,7 +7,7 @@ export * as validation from './lib/validation';
 export * as onboarding from './lib/onboarding';
 
 export { default as LocalWallet } from './clients/modules/local-wallet';
-export { Subaccount as SubaccountClient } from './clients/subaccount';
+export { SubaccountInfo as SubaccountClient } from './clients/subaccount';
 export { CompositeClient } from './clients/composite-client';
 export { IndexerClient } from './clients/indexer-client';
 export { ValidatorClient } from './clients/validator-client';


### PR DESCRIPTION
There's one Subaccount already in proto generated types. That is the type that is returned when we query the chain.
```
import { Subaccount } from '@dydxprotocol/v4-client-js/build/src/clients/modules/proto-includes';
import { Subaccount as SubaccountClient } from '@dydxprotocol/v4-client-js/build/src/clients/subaccount';
```

This new `SubaccountInfo` is used to represent Subaccount tuples of (wallet, subaccountNumber) in our clients.

Bumped 1.0.0 to 1.0.1