### PR TITLE
Base64-decode Noble IBC payload

### DIFF
--- a/v4-client-js/src/clients/native.ts
+++ b/v4-client-js/src/clients/native.ts
@@ -1066,7 +1066,11 @@ export async function withdrawToNobleIBC(payload: string): Promise<String> {
     const json = JSON.parse(payload);
 
     const { subaccountNumber, amount, ibcPayload } = json ?? {};
-    const parsedIbcPayload = JSON.parse(ibcPayload);
+
+    const decode = (str: string):string => Buffer.from(str, 'base64').toString('binary');
+    const decoded = decode(ibcPayload);
+
+    const parsedIbcPayload = JSON.parse(decoded);
 
     const msg = client.withdrawFromSubaccountMessage(
       new SubaccountInfo(wallet, subaccountNumber),


### PR DESCRIPTION
The iOS client has issue passing in the string-encoded JSON payload embedded in another JSON.  Will switch to use base64-encoded payload instead.