### PR TITLE
v1.0.18: Add Withdraw Gating/Capacity query methods

### DIFF
--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",
@@ -16,7 +16,7 @@
         "@cosmjs/stargate": "^0.32.1",
         "@cosmjs/tendermint-rpc": "^0.32.1",
         "@cosmjs/utils": "^0.32.1",
-        "@dydxprotocol/v4-proto": "3.0.0-dev.0",
+        "@dydxprotocol/v4-proto": "4.0.0-dev.0",
         "@osmonauts/lcd": "^0.6.0",
         "@scure/bip32": "^1.1.5",
         "@scure/bip39": "^1.1.1",
@@ -3027,9 +3027,9 @@
       }
     },
     "node_modules/@dydxprotocol/v4-proto": {
-      "version": "3.0.0-dev.0",
-      "resolved": "https://registry.npmjs.org/@dydxprotocol/v4-proto/-/v4-proto-3.0.0-dev.0.tgz",
-      "integrity": "sha512-hT6F/AgaTqv8Bwo7twpIhmjXvJE/Fx+3mmHHTuIXMeL6OhVtlOpcEQyHvBEAdh1VrNq/S7qWvdQD0fvC/UgKyA==",
+      "version": "4.0.0-dev.0",
+      "resolved": "https://registry.npmjs.org/@dydxprotocol/v4-proto/-/v4-proto-4.0.0-dev.0.tgz",
+      "integrity": "sha512-PC/xq5YJIisAd3jjIULJGrnujbrYkr5h4ehepnLc6U34nJT720iumKVMiPaezwRC+kHKTI1culpKNnlMnbeYBA==",
       "dependencies": {
         "protobufjs": "^6.11.2"
       }
@@ -19389,9 +19389,9 @@
       }
     },
     "@dydxprotocol/v4-proto": {
-      "version": "3.0.0-dev.0",
-      "resolved": "https://registry.npmjs.org/@dydxprotocol/v4-proto/-/v4-proto-3.0.0-dev.0.tgz",
-      "integrity": "sha512-hT6F/AgaTqv8Bwo7twpIhmjXvJE/Fx+3mmHHTuIXMeL6OhVtlOpcEQyHvBEAdh1VrNq/S7qWvdQD0fvC/UgKyA==",
+      "version": "4.0.0-dev.0",
+      "resolved": "https://registry.npmjs.org/@dydxprotocol/v4-proto/-/v4-proto-4.0.0-dev.0.tgz",
+      "integrity": "sha512-PC/xq5YJIisAd3jjIULJGrnujbrYkr5h4ehepnLc6U34nJT720iumKVMiPaezwRC+kHKTI1culpKNnlMnbeYBA==",
       "requires": {
         "protobufjs": "^6.11.2"
       }

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {
@@ -37,7 +37,7 @@
     "@cosmjs/stargate": "^0.32.1",
     "@cosmjs/tendermint-rpc": "^0.32.1",
     "@cosmjs/utils": "^0.32.1",
-    "@dydxprotocol/v4-proto": "3.0.0-dev.0",
+    "@dydxprotocol/v4-proto": "4.0.0-dev.0",
     "@osmonauts/lcd": "^0.6.0",
     "@scure/bip32": "^1.1.5",
     "@scure/bip39": "^1.1.1",

--- a/v4-client-js/src/clients/modules/get.ts
+++ b/v4-client-js/src/clients/modules/get.ts
@@ -504,7 +504,7 @@ export class Get {
     return GovV1Module.QueryProposalsResponse.decode(data);
   }
 
-  async getWithdrawGatingStatus(
+  async GetWithdrawalAndTransferGatingStatus(
   ): Promise<SubaccountsModule.QueryGetWithdrawalAndTransfersBlockedInfoResponse> {
     const requestData = Uint8Array.from(
       SubaccountsModule.QueryGetWithdrawalAndTransfersBlockedInfoRequest
@@ -520,7 +520,7 @@ export class Get {
     return SubaccountsModule.QueryGetWithdrawalAndTransfersBlockedInfoResponse.decode(data);
   }
 
-  async getWithdrawLimitForSubaccount(
+  async getWithdrawalCapacityByDenom(
     denom: string,
   ): Promise<RateLimitModule.QueryCapacityByDenomResponse> {
     const requestData = Uint8Array.from(

--- a/v4-client-js/src/clients/modules/get.ts
+++ b/v4-client-js/src/clients/modules/get.ts
@@ -23,6 +23,7 @@ import {
   PerpetualsModule,
   PricesModule,
   ProposalStatus,
+  RateLimitModule,
   RewardsModule,
   StakingModule,
   StatsModule,
@@ -501,6 +502,41 @@ export class Get {
       requestData,
     );
     return GovV1Module.QueryProposalsResponse.decode(data);
+  }
+
+  async getWithdrawGatingStatus(
+  ): Promise<SubaccountsModule.QueryGetWithdrawalAndTransfersBlockedInfoResponse> {
+    const requestData = Uint8Array.from(
+      SubaccountsModule.QueryGetWithdrawalAndTransfersBlockedInfoRequest
+        .encode({})
+        .finish(),
+    );
+
+    const data = await this.sendQuery(
+      '/dydxprotocol.subaccounts.Query/GetWithdrawalAndTransfersBlockedInfo',
+      requestData,
+    );
+
+    return SubaccountsModule.QueryGetWithdrawalAndTransfersBlockedInfoResponse.decode(data);
+  }
+
+  async getWithdrawLimitForSubaccount(
+    denom: string,
+  ): Promise<RateLimitModule.QueryCapacityByDenomResponse> {
+    const requestData = Uint8Array.from(
+      RateLimitModule.QueryCapacityByDenomRequest
+        .encode({
+          denom,
+        })
+        .finish(),
+    );
+
+    const data = await this.sendQuery(
+      '/dydxprotocol.ratelimit.Query/CapacityByDenom',
+      requestData,
+    );
+
+    return RateLimitModule.QueryCapacityByDenomResponse.decode(data);
   }
 
   private async sendQuery(requestUrl: string, requestData: Uint8Array): Promise<Uint8Array> {

--- a/v4-client-js/src/clients/modules/proto-includes.ts
+++ b/v4-client-js/src/clients/modules/proto-includes.ts
@@ -6,6 +6,7 @@ export * as PerpetualsModule from '@dydxprotocol/v4-proto/src/codegen/dydxprotoc
 export * as PricesModule from '@dydxprotocol/v4-proto/src/codegen/dydxprotocol/prices/query';
 export * as SubaccountsModule from '@dydxprotocol/v4-proto/src/codegen/dydxprotocol/subaccounts/query';
 export * as FeeTierModule from '@dydxprotocol/v4-proto/src/codegen/dydxprotocol/feetiers/query';
+export * as RateLimitModule from '@dydxprotocol/v4-proto/src/codegen/dydxprotocol/ratelimit/query';
 export * as RewardsModule from '@dydxprotocol/v4-proto/src/codegen/dydxprotocol/rewards/query';
 export * as StakingModule from '@dydxprotocol/v4-proto/src/codegen/cosmos/staking/v1beta1/query';
 export * as BridgeModule from '@dydxprotocol/v4-proto/src/codegen/dydxprotocol/bridge/query';


### PR DESCRIPTION
Add two new methods to `ValidatorClient`
- `getWithdrawalAndTransferGatingStatus`
- `getWithdrawalCapacityByDenom`

bump `v4-protos-js@4.0.0-dev.0`
codegen `v4-native-client`

Tested locally with the resulting responses:
<img width="797" alt="Screen Shot 2024-01-31 at 4 43 04 PM" src="https://github.com/dydxprotocol/v4-clients/assets/13111994/38b85817-43e9-42fb-a5e9-b9bae455c77e">
