### PR TITLE
v1.0.19: Update expected type for Initial deposit amount

### DIFF
--- a/v4-client-js/examples/gov_add_new_market.ts
+++ b/v4-client-js/examples/gov_add_new_market.ts
@@ -68,7 +68,7 @@ async function test(): Promise<void> {
     MOCK_DATA,
     getGovAddNewMarketTitle(MOCK_DATA.ticker),
     getGovAddNewMarketSummary(MOCK_DATA.ticker, MOCK_DATA.delayBlocks),
-    INITIAL_DEPOSIT_AMOUNT,
+    BigInt(INITIAL_DEPOSIT_AMOUNT).toString(),
   );
   console.log('**Tx**');
   console.log(tx);

--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.0.18",
+      "version": "1.0.19",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/composite-client.ts
+++ b/v4-client-js/src/clients/composite-client.ts
@@ -1018,7 +1018,7 @@ export class CompositeClient {
     params: GovAddNewMarketParams,
     title: string,
     summary: string,
-    initialDepositAmount: number,
+    initialDepositAmount: string,
   ): Promise<BroadcastTxAsyncResponse | BroadcastTxSyncResponse | IndexedTx> {
     const msg: Promise<EncodeObject[]> = new Promise((resolve) => {
       const composer = this.validatorClient.post.composer;

--- a/v4-client-js/src/clients/modules/composer.ts
+++ b/v4-client-js/src/clients/modules/composer.ts
@@ -383,7 +383,7 @@ export class Composer {
   // ------------ x/gov ------------
   public composeMsgSubmitProposal(
     title: string,
-    initialDepositAmount: number,
+    initialDepositAmount: string,
     initialDepositDenomConfig: DenomConfig,
     summary: string,
     messages: EncodeObject[],
@@ -392,7 +392,7 @@ export class Composer {
     expedited: boolean = false,
   ): EncodeObject {
     const initialDeposit: Coin[] = [{
-      amount: initialDepositAmount.toString(),
+      amount: initialDepositAmount,
       denom: initialDepositDenomConfig.CHAINTOKEN_DENOM,
     }];
 


### PR DESCRIPTION
JS numbers that are too large result in scientific notation. In this specific case, `1e22` which could not be parsed when composing a governance proposal.

Changed expected type from `number` -> `string`