### PR TITLE
Allow clients to set a default memo to for transactions

### DIFF
--- a/v4-client-js/examples/noble_example.ts
+++ b/v4-client-js/examples/noble_example.ts
@@ -23,7 +23,7 @@ async function test(): Promise<void> {
     NOBLE_BECH32_PREFIX,
   );
 
-  const client = new NobleClient('https://rpc.testnet.noble.strange.love');
+  const client = new NobleClient('https://rpc.testnet.noble.strange.love', 'Noble example');
   await client.connect(nobleWallet);
 
   if (nobleWallet.address === undefined || dydxWallet.address === undefined) {

--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.0.18",
+      "version": "1.0.19",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/composite-client.ts
+++ b/v4-client-js/src/clients/composite-client.ts
@@ -278,6 +278,7 @@ export class CompositeClient {
     goodTilBlock: number,
     timeInForce: Order_TimeInForce,
     reduceOnly: boolean,
+    memo?: string,
   ): Promise<BroadcastTxAsyncResponse | BroadcastTxSyncResponse | IndexedTx> {
     const msgs: Promise<EncodeObject[]> = new Promise((resolve) => {
       const msg = this.placeShortTermOrderMessage(
@@ -304,7 +305,7 @@ export class CompositeClient {
       () => msgs,
       true,
       undefined,
-      undefined,
+      memo,
       () => account,
     );
   }
@@ -356,6 +357,7 @@ export class CompositeClient {
     triggerPrice?: number,
     marketInfo?: MarketInfo,
     currentHeight?: number,
+    memo?: string,
   ): Promise<BroadcastTxAsyncResponse | BroadcastTxSyncResponse | IndexedTx> {
     const msgs: Promise<EncodeObject[]> = new Promise((resolve) => {
       const msg = this.placeOrderMessage(
@@ -390,7 +392,7 @@ export class CompositeClient {
       () => msgs,
       true,
       undefined,
-      undefined,
+      memo,
       () => account,
     );
   }
@@ -704,6 +706,7 @@ export class CompositeClient {
     recipientAddress: string,
     recipientSubaccountNumber: number,
     amount: string,
+    memo?: string,
   ): Promise<BroadcastTxAsyncResponse | BroadcastTxSyncResponse | IndexedTx> {
     const msgs: Promise<EncodeObject[]> = new Promise((resolve) => {
       const msg = this.transferToSubaccountMessage(
@@ -717,7 +720,10 @@ export class CompositeClient {
     return this.send(
       subaccount.wallet,
       () => msgs,
-      true);
+      true,
+      undefined,
+      memo,
+    );
   }
 
   /**
@@ -774,6 +780,7 @@ export class CompositeClient {
   async depositToSubaccount(
     subaccount: SubaccountInfo,
     amount: string,
+    memo?: string,
   ): Promise<BroadcastTxAsyncResponse | BroadcastTxSyncResponse | IndexedTx> {
     const msgs: Promise<EncodeObject[]> = new Promise((resolve) => {
       const msg = this.depositToSubaccountMessage(
@@ -784,7 +791,10 @@ export class CompositeClient {
     });
     return this.validatorClient.post.send(subaccount.wallet,
       () => msgs,
-      false);
+      false,
+      undefined,
+      memo,
+    );
   }
 
   /**
@@ -836,6 +846,7 @@ export class CompositeClient {
     subaccount: SubaccountInfo,
     amount: string,
     recipient?: string,
+    memo?: string,
   ): Promise<BroadcastTxAsyncResponse | BroadcastTxSyncResponse | IndexedTx> {
     const msgs: Promise<EncodeObject[]> = new Promise((resolve) => {
       const msg = this.withdrawFromSubaccountMessage(
@@ -848,7 +859,10 @@ export class CompositeClient {
     return this.send(
       subaccount.wallet,
       () => msgs,
-      false);
+      false,
+      undefined,
+      memo,
+    );
   }
 
   /**
@@ -1019,6 +1033,7 @@ export class CompositeClient {
     title: string,
     summary: string,
     initialDepositAmount: number,
+    memo?: string,
   ): Promise<BroadcastTxAsyncResponse | BroadcastTxSyncResponse | IndexedTx> {
     const msg: Promise<EncodeObject[]> = new Promise((resolve) => {
       const composer = this.validatorClient.post.composer;
@@ -1093,6 +1108,8 @@ export class CompositeClient {
       wallet,
       () => msg,
       false,
+      undefined,
+      memo,
     );
   }
 }

--- a/v4-client-js/src/clients/constants.ts
+++ b/v4-client-js/src/clients/constants.ts
@@ -180,18 +180,21 @@ export class ValidatorConfig {
   public chainId: string;
   public denoms: DenomConfig;
   public broadcastOptions?: BroadcastOptions;
+  public defaultClientMemo?: string;
 
   constructor(
     restEndpoint: string,
     chainId: string,
     denoms: DenomConfig,
     broadcastOptions?: BroadcastOptions,
+    defaultClientMemo?: string,
   ) {
     this.restEndpoint = restEndpoint?.endsWith('/') ? restEndpoint.slice(0, -1) : restEndpoint;
     this.chainId = chainId;
 
     this.denoms = denoms;
     this.broadcastOptions = broadcastOptions;
+    this.defaultClientMemo = defaultClientMemo;
   }
 }
 
@@ -214,7 +217,7 @@ export class Network {
         USDC_GAS_DENOM: 'uusdc',
         USDC_DECIMALS: 6,
         CHAINTOKEN_DECIMALS: 18,
-      });
+      }, undefined, 'Client Example');
     return new Network('testnet', indexerConfig, validatorConfig);
   }
 
@@ -230,7 +233,7 @@ export class Network {
         USDC_GAS_DENOM: 'uusdc',
         USDC_DECIMALS: 6,
         CHAINTOKEN_DECIMALS: 18,
-      });
+      }, undefined, 'Client Example');
     return new Network('local', indexerConfig, validatorConfig);
   }
 

--- a/v4-client-js/src/clients/modules/post.ts
+++ b/v4-client-js/src/clients/modules/post.ts
@@ -54,6 +54,7 @@ export class Post {
     private readonly chainId: string;
     public readonly get: Get;
     public readonly denoms: DenomConfig;
+    public readonly defaultClientMemo?: string;
 
     public readonly defaultGasPrice: GasPrice;
     public readonly defaultDydxGasPrice: GasPrice;
@@ -64,12 +65,14 @@ export class Post {
       get: Get,
       chainId: string,
       denoms: DenomConfig,
+      defaultClientMemo?: string,
     ) {
       this.get = get;
       this.chainId = chainId;
       this.registry = generateRegistry();
       this.composer = new Composer();
       this.denoms = denoms;
+      this.defaultClientMemo = defaultClientMemo;
       this.defaultGasPrice = GasPrice
         .fromString(`0.025${denoms.USDC_GAS_DENOM !== undefined ? denoms.USDC_GAS_DENOM : denoms.USDC_DENOM}`);
       this.defaultDydxGasPrice = GasPrice
@@ -156,7 +159,7 @@ export class Post {
         msgs,
         zeroFee,
         gasPrice,
-        memo,
+        memo ?? this.defaultClientMemo,
         broadcastMode ?? this.defaultBroadcastMode(msgs),
       );
     }

--- a/v4-client-js/src/clients/native.ts
+++ b/v4-client-js/src/clients/native.ts
@@ -37,6 +37,8 @@ declare global {
   var nobleWallet: LocalWallet | undefined;
 }
 
+const DEFAULT_NATIVE_MEMO = 'dYdX Frontend (native)';
+
 export async function connectClient(
   network: Network,
 ): Promise<string> {
@@ -81,15 +83,22 @@ export async function connectNetwork(
       throw new UserError('Missing required token params');
     }
 
-    const indexerConfig = new IndexerConfig(indexerUrl, websocketUrl);
-    const validatorConfig = new ValidatorConfig(validatorUrl, chainId, {
+    const denomConfig = {
       USDC_DENOM,
       USDC_DECIMALS,
       USDC_GAS_DENOM,
       CHAINTOKEN_DENOM,
       CHAINTOKEN_DECIMALS,
       CHAINTOKEN_GAS_DENOM,
-    });
+    };
+    const indexerConfig = new IndexerConfig(indexerUrl, websocketUrl);
+    const validatorConfig = new ValidatorConfig(
+      validatorUrl,
+      chainId,
+      denomConfig,
+      undefined,
+      DEFAULT_NATIVE_MEMO,
+    );
     const config = new Network('native', indexerConfig, validatorConfig);
     globalThis.client = await CompositeClient.connect(config);
     if (faucetUrl !== undefined) {
@@ -99,7 +108,7 @@ export async function connectNetwork(
     }
 
     try {
-      globalThis.nobleClient = new NobleClient(nobleValidatorUrl);
+      globalThis.nobleClient = new NobleClient(nobleValidatorUrl, DEFAULT_NATIVE_MEMO);
       if (globalThis.nobleWallet) {
         await globalThis.nobleClient.connect(globalThis.nobleWallet);
       }

--- a/v4-client-js/src/clients/noble-client.ts
+++ b/v4-client-js/src/clients/noble-client.ts
@@ -17,9 +17,11 @@ export class NobleClient {
   private wallet?: LocalWallet;
   private restEndpoint: string;
   private stargateClient?: SigningStargateClient;
+  private defaultClientMemo?: string;
 
-  constructor(restEndpoint: string) {
+  constructor(restEndpoint: string, defaultClientMemo?: string) {
     this.restEndpoint = restEndpoint;
+    this.defaultClientMemo = defaultClientMemo;
   }
 
   get isConnected(): boolean {
@@ -74,14 +76,14 @@ export class NobleClient {
       throw new Error('NobleClient wallet not initialized');
     }
     // Simulate to get the gas estimate
-    const fee = await this.simulateTransaction(messages, gasPrice, memo);
+    const fee = await this.simulateTransaction(messages, gasPrice, memo ?? this.defaultClientMemo);
 
     // Sign and broadcast the transaction
     return this.stargateClient.signAndBroadcast(
       this.wallet.address,
       messages,
       fee,
-      memo ?? '',
+      memo ?? this.defaultClientMemo,
     );
   }
 

--- a/v4-client-js/src/clients/validator-client.ts
+++ b/v4-client-js/src/clients/validator-client.ts
@@ -69,6 +69,11 @@ export class ValidatorClient {
       setupTxExtension,
     );
     this._get = new Get(tendermintClient, queryClient);
-    this._post = new Post(this._get!, this.config.chainId, this.config.denoms);
+    this._post = new Post(
+      this._get!,
+      this.config.chainId,
+      this.config.denoms,
+      this.config.defaultClientMemo,
+    );
   }
 }


### PR DESCRIPTION
Having Memos for our transactions is useful for research on-chain analysis to track which transactions are made by are front-end.