### PR TITLE
default broadcast mode for MsgCancelOrder

### DIFF
--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.0.20",
+      "version": "1.0.21",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/modules/post.ts
+++ b/v4-client-js/src/clients/modules/post.ts
@@ -38,7 +38,7 @@ import { Composer } from './composer';
 import { Get } from './get';
 import LocalWallet from './local-wallet';
 import {
-  Order_Side, Order_TimeInForce, Any, MsgPlaceOrder, Order_ConditionType,
+  Order_Side, Order_TimeInForce, Any, MsgPlaceOrder, MsgCancelOrder, Order_ConditionType,
 } from './proto-includes';
 
 // Required for encoding and decoding queries that are of type Long.
@@ -168,9 +168,15 @@ export class Post {
      * @description Calculate the default broadcast mode.
      */
     private defaultBroadcastMode(msgs: EncodeObject[]): BroadcastMode {
-      if (msgs.length === 1 && msgs[0].typeUrl === '/dydxprotocol.clob.MsgPlaceOrder') {
-        const msg = msgs[0].value as MsgPlaceOrder;
-        const orderFlags = msg.order?.orderId?.orderFlags;
+      if (
+        msgs.length === 1 &&
+        (msgs[0].typeUrl === '/dydxprotocol.clob.MsgPlaceOrder' ||
+          msgs[0].typeUrl === '/dydxprotocol.clob.MsgCancelOrder')
+      ) {
+        const orderFlags = msgs[0].typeUrl === '/dydxprotocol.clob.MsgPlaceOrder'
+          ? (msgs[0].value as MsgPlaceOrder).order?.orderId?.orderFlags
+          : (msgs[0].value as MsgCancelOrder).orderId?.orderFlags;
+
         switch (orderFlags) {
           case OrderFlags.SHORT_TERM:
             return Method.BroadcastTxSync;


### PR DESCRIPTION
same logic as MsgPlaceOrder, broadcast mode should be `Method.BroadcastTxCommit` for long term order cancels, so that FE can properly wait for order cancel to commit before sending another cancel order tx