### PR TITLE
MOB-298 : support custom txn memo field parameter for native libs

### DIFF
--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.0.21",
+      "version": "1.0.22",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/native.ts
+++ b/v4-client-js/src/clients/native.ts
@@ -37,8 +37,6 @@ declare global {
   var nobleWallet: LocalWallet | undefined;
 }
 
-const DEFAULT_NATIVE_MEMO = 'dYdX Frontend (native)';
-
 export async function connectClient(
   network: Network,
 ): Promise<string> {
@@ -68,6 +66,7 @@ export async function connectNetwork(
       CHAINTOKEN_DENOM,
       CHAINTOKEN_DECIMALS,
       CHAINTOKEN_GAS_DENOM,
+      txnMemo,
     } = params;
 
     if (indexerUrl === undefined ||
@@ -81,6 +80,9 @@ export async function connectNetwork(
       CHAINTOKEN_DENOM === undefined ||
       CHAINTOKEN_DECIMALS === undefined) {
       throw new UserError('Missing required token params');
+    }
+    if (txnMemo === undefined) {
+      throw new UserError('Missing required transaction memo (`txnMemo`)');
     }
 
     const denomConfig = {
@@ -97,7 +99,7 @@ export async function connectNetwork(
       chainId,
       denomConfig,
       undefined,
-      DEFAULT_NATIVE_MEMO,
+      txnMemo,
     );
     const config = new Network('native', indexerConfig, validatorConfig);
     globalThis.client = await CompositeClient.connect(config);
@@ -108,7 +110,7 @@ export async function connectNetwork(
     }
 
     try {
-      globalThis.nobleClient = new NobleClient(nobleValidatorUrl, DEFAULT_NATIVE_MEMO);
+      globalThis.nobleClient = new NobleClient(nobleValidatorUrl, txnMemo);
       if (globalThis.nobleWallet) {
         await globalThis.nobleClient.connect(globalThis.nobleWallet);
       }


### PR DESCRIPTION
[MOB-298 : support custom txn memo field parameter for native libs](https://linear.app/dydx/issue/MOB-298/support-custom-txn-memo-field-parameter-for-native-libs)

in order to differentiate iOS and Android txns in the memo, the memo description must be configurable for clients