### PR TITLE
add default broadcast mode for conditional orders

### DIFF
--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/modules/post.ts
+++ b/v4-client-js/src/clients/modules/post.ts
@@ -182,6 +182,7 @@ export class Post {
             return Method.BroadcastTxSync;
 
           case OrderFlags.LONG_TERM:
+          case OrderFlags.CONDITIONAL:
             return Method.BroadcastTxCommit;
 
           default:


### PR DESCRIPTION
conditional orders also require sequence numbers (all stateful use seq numbers) -- therefore should wait before previous tx to commit before submitting a new one, similar to long term orders