### PR TITLE
Send status to the native faucet call

### DIFF
--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.0.23",
+      "version": "1.0.24",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/native.ts
+++ b/v4-client-js/src/clients/native.ts
@@ -22,6 +22,7 @@ import LocalWallet from './modules/local-wallet';
 import { NobleClient } from './noble-client';
 import { SubaccountInfo } from './subaccount';
 import { OrderFlags, SquidIBCPayload } from './types';
+import { Response } from './lib/axios';
 
 declare global {
   // eslint-disable-next-line vars-on-top, no-var
@@ -461,8 +462,13 @@ export async function faucet(
     }
 
     const response = await faucetClient.fill(wallet.address!, subaccountNumber, amount);
+    const sanitized: Response = {
+      data: response.data,
+      status: response.status,
+      headers: response.headers,
+    };
 
-    return encodeJson(response.data);
+    return encodeJson(sanitized);
   } catch (error) {
     return wrappedError(error);
   }

--- a/v4-client-js/src/clients/native.ts
+++ b/v4-client-js/src/clients/native.ts
@@ -18,11 +18,11 @@ import {
   Network, OrderType, OrderSide, OrderTimeInForce, OrderExecution, IndexerConfig, ValidatorConfig,
 } from './constants';
 import { FaucetClient } from './faucet-client';
+import { Response } from './lib/axios';
 import LocalWallet from './modules/local-wallet';
 import { NobleClient } from './noble-client';
 import { SubaccountInfo } from './subaccount';
 import { OrderFlags, SquidIBCPayload } from './types';
-import { Response } from './lib/axios';
 
 declare global {
   // eslint-disable-next-line vars-on-top, no-var


### PR DESCRIPTION
Correct a mistake in a [previous PR](https://github.com/dydxprotocol/v4-clients/pull/126).  Abacus is expecting the status code as well, so we need to pass it over.