### PR TITLE
MOB-2 : iOS: Update dydxClient hook to support query for withdrawal gating

### DIFF
--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/native.ts
+++ b/v4-client-js/src/clients/native.ts
@@ -1184,3 +1184,23 @@ export async function cctpWithdraw(squidPayload: string): Promise<String> {
     return wrappedError(error);
   }
 }
+
+export async function getWithdrawalCapacityByDenom(denom: string): Promise<string> {
+  try {
+    const validatorClient = globalThis.client.validatorClient;
+    const result = await validatorClient.get.getWithdrawalCapacityByDenom(denom);
+    return encodeJson(result);
+  } catch (e) {
+    return wrappedError(e);
+  }
+}
+
+export async function getWithdrawalAndTransferGatingStatus(): Promise<string> {
+  try {
+    const validatorClient = globalThis.client.validatorClient;
+    const result = await validatorClient.get.GetWithdrawalAndTransferGatingStatus();
+    return encodeJson(result);
+  } catch (e) {
+    return wrappedError(e);
+  }
+}

--- a/v4-client-js/src/clients/native.ts
+++ b/v4-client-js/src/clients/native.ts
@@ -1198,7 +1198,7 @@ export async function getWithdrawalCapacityByDenom(denom: string): Promise<strin
 export async function getWithdrawalAndTransferGatingStatus(): Promise<string> {
   try {
     const validatorClient = globalThis.client.validatorClient;
-    const result = await validatorClient.get.GetWithdrawalAndTransferGatingStatus();
+    const result = await validatorClient.get.getWithdrawalAndTransferGatingStatus();
     return encodeJson(result, ByteArrayEncoding.BIGINT);
   } catch (e) {
     return wrappedError(e);

--- a/v4-client-js/src/clients/native.ts
+++ b/v4-client-js/src/clients/native.ts
@@ -1189,7 +1189,7 @@ export async function getWithdrawalCapacityByDenom(denom: string): Promise<strin
   try {
     const validatorClient = globalThis.client.validatorClient;
     const result = await validatorClient.get.getWithdrawalCapacityByDenom(denom);
-    return encodeJson(result);
+    return encodeJson(result, ByteArrayEncoding.BIGINT);
   } catch (e) {
     return wrappedError(e);
   }
@@ -1199,7 +1199,7 @@ export async function getWithdrawalAndTransferGatingStatus(): Promise<string> {
   try {
     const validatorClient = globalThis.client.validatorClient;
     const result = await validatorClient.get.GetWithdrawalAndTransferGatingStatus();
-    return encodeJson(result);
+    return encodeJson(result, ByteArrayEncoding.BIGINT);
   } catch (e) {
     return wrappedError(e);
   }


### PR DESCRIPTION
[MOB-2 : iOS: Update dydxClient hook to support query for withdrawal gating](https://linear.app/dydx/issue/MOB-2/ios-update-dydxclient-hook-to-support-query-for-withdrawal-gating)

- adds native wrappers for the `GetWithdrawalAndTransferGatingStatus ` and `getWithdrawalCapacityByDenom` methods

