### PR TITLE
Fix get order api request

### DIFF
--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/modules/account.ts
+++ b/v4-client-js/src/clients/modules/account.ts
@@ -109,7 +109,7 @@ export default class AccountClient extends RestClient {
   }
 
   async getOrder(orderId: string) : Promise<Data> {
-    const uri = `/v4/orders${orderId}`;
+    const uri = `/v4/orders/${orderId}`;
     return this.get(uri);
   }
 


### PR DESCRIPTION
The client is trying to go to `/v4/orders${orderId}` and is missing the `/` that is required between `orders` and `${orderId}`.