### PR TITLE
Mobile: Passing defaultDydxGasPrice for DYDX token transfer

### DIFF
--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/native.ts
+++ b/v4-client-js/src/clients/native.ts
@@ -561,6 +561,8 @@ export async function transferNativeToken(
         return encodeObjects;
       },
       false,
+      client.validatorClient.post.defaultDydxGasPrice,
+      undefined,
     );
     return encodeJson(tx);
   } catch (error) {

--- a/v4-client-js/src/clients/native.ts
+++ b/v4-client-js/src/clients/native.ts
@@ -750,6 +750,7 @@ export async function simulateTransferNativeToken(
       () => {
         return encodeObjects;
       },
+      client.validatorClient.post.defaultDydxGasPrice,
     );
     return encodeJson(stdFee);
   } catch (error) {


### PR DESCRIPTION
If defaultDydxGasPrice is not supplied, validatorClient will use defaultGasPrice (USDC), which could cause the transaction to fail.