### PR TITLE
v1.1.10: Gas denom selection

### DIFF
--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.1.9",
+      "version": "1.1.10",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/composite-client.ts
+++ b/v4-client-js/src/clients/composite-client.ts
@@ -18,6 +18,7 @@ import {
   OrderType,
   SHORT_BLOCK_FORWARD,
   SHORT_BLOCK_WINDOW,
+  SelectedGasDenom,
 } from './constants';
 import {
   calculateQuantums,
@@ -53,6 +54,7 @@ export interface MarketInfo {
 
 export class CompositeClient {
   public readonly network: Network;
+  public gasDenom: SelectedGasDenom = SelectedGasDenom.USDC;
   private _indexerClient: IndexerClient;
   private _validatorClient?: ValidatorClient;
 
@@ -89,6 +91,16 @@ export class CompositeClient {
      * Get the validator client
      */
     return this._validatorClient!;
+  }
+
+  get selectedGasDenom(): SelectedGasDenom | undefined {
+    if (!this._validatorClient) return undefined;
+    return this._validatorClient.selectedGasDenom;
+  }
+
+  setSelectedGasDenom(gasDenom: SelectedGasDenom): void {
+    if (!this._validatorClient) throw new Error('Validator client not initialized');
+    this._validatorClient.setSelectedGasDenom(gasDenom);
   }
 
   /**

--- a/v4-client-js/src/clients/constants.ts
+++ b/v4-client-js/src/clients/constants.ts
@@ -57,6 +57,12 @@ export const NETWORK_ID_TESTNET: string = 'dydxprotocol-testnet';
 // For the deployment by DYDX token holders
 export const NETWORK_ID_MAINNET: string = 'dydx-mainnet-1';
 
+// ------------ Gas Denoms ------------
+export enum SelectedGasDenom {
+  NATIVE,
+  USDC,
+}
+
 // ------------ MsgType URLs ------------
 // Default CosmosSDK
 // x/bank

--- a/v4-client-js/src/clients/faucet-client.ts
+++ b/v4-client-js/src/clients/faucet-client.ts
@@ -37,7 +37,7 @@ export class FaucetClient extends RestClient {
     address: string,
     headers?: {},
   ): Promise<Response> {
-    const uri = '/faucet/native-tokens';
+    const uri = '/faucet/native-token';
 
     return this.post(
       uri,

--- a/v4-client-js/src/clients/faucet-client.ts
+++ b/v4-client-js/src/clients/faucet-client.ts
@@ -26,4 +26,26 @@ export class FaucetClient extends RestClient {
       headers,
     );
   }
+
+  /**
+   * @description For testnet only, add native tokens to an address
+   * @param address destination address for native tokens
+   * @param headers requestHeaders
+   * @returns The HTTP response.
+   */
+  public async fillNative(
+    address: string,
+    headers?: {},
+  ): Promise<Response> {
+    const uri = '/faucet/native-tokens';
+
+    return this.post(
+      uri,
+      {},
+      {
+        address,
+      },
+      headers,
+    );
+  }
 }

--- a/v4-client-js/src/clients/modules/post.ts
+++ b/v4-client-js/src/clients/modules/post.ts
@@ -22,7 +22,7 @@ import _ from 'lodash';
 import Long from 'long';
 import protobuf from 'protobufjs';
 
-import { GAS_MULTIPLIER } from '../constants';
+import { GAS_MULTIPLIER, SelectedGasDenom } from '../constants';
 import { UnexpectedClientError } from '../lib/errors';
 import { generateRegistry } from '../lib/registry';
 import { SubaccountInfo } from '../subaccount';
@@ -56,6 +56,7 @@ export class Post {
     public readonly denoms: DenomConfig;
     public readonly defaultClientMemo?: string;
 
+    public selectedGasDenom: SelectedGasDenom = SelectedGasDenom.USDC;
     public readonly defaultGasPrice: GasPrice;
     public readonly defaultDydxGasPrice: GasPrice;
 
@@ -79,6 +80,16 @@ export class Post {
         .fromString(`25000000000${denoms.CHAINTOKEN_GAS_DENOM !== undefined ? denoms.CHAINTOKEN_GAS_DENOM : denoms.CHAINTOKEN_DENOM}`);
     }
 
+    setSelectedGasDenom(selectedGasDenom: SelectedGasDenom): void {
+      this.selectedGasDenom = selectedGasDenom;
+    }
+
+    getGasPrice(): GasPrice {
+      return this.selectedGasDenom === SelectedGasDenom.USDC
+        ? this.defaultGasPrice
+        : this.defaultDydxGasPrice;
+    }
+
     /**
      * @description Simulate a transaction
      * the calling function is responsible for creating the messages.
@@ -90,7 +101,7 @@ export class Post {
     async simulate(
       wallet: LocalWallet,
       messaging: () => Promise<EncodeObject[]>,
-      gasPrice: GasPrice = this.defaultGasPrice,
+      gasPrice: GasPrice = this.getGasPrice(),
       memo?: string,
       account?: () => Promise<Account>,
     ): Promise<StdFee> {
@@ -120,7 +131,7 @@ export class Post {
       wallet: LocalWallet,
       messaging: () => Promise<EncodeObject[]>,
       zeroFee: boolean,
-      gasPrice: GasPrice = this.defaultGasPrice,
+      gasPrice: GasPrice = this.getGasPrice(),
       memo?: string,
       account?: () => Promise<Account>,
     ): Promise<Uint8Array> {
@@ -143,7 +154,7 @@ export class Post {
       wallet: LocalWallet,
       messaging: () => Promise<EncodeObject[]>,
       zeroFee: boolean,
-      gasPrice: GasPrice = this.defaultGasPrice,
+      gasPrice: GasPrice = this.getGasPrice(),
       memo?: string,
       broadcastMode?: BroadcastMode,
       account?: () => Promise<Account>,
@@ -202,7 +213,7 @@ export class Post {
       messages: EncodeObject[],
       account: Account,
       zeroFee: boolean,
-      gasPrice: GasPrice = this.defaultGasPrice,
+      gasPrice: GasPrice = this.getGasPrice(),
       memo?: string,
     ): Promise<Uint8Array> {
       // Simulate transaction if no fee is specified.
@@ -258,7 +269,7 @@ export class Post {
       account: Account,
       messages: EncodeObject[],
       zeroFee: boolean,
-      gasPrice: GasPrice = this.defaultGasPrice,
+      gasPrice: GasPrice = this.getGasPrice(),
       memo?: string,
       broadcastMode?: BroadcastMode,
     ): Promise<BroadcastTxAsyncResponse | BroadcastTxSyncResponse | IndexedTx> {
@@ -301,7 +312,7 @@ export class Post {
       pubKey: Secp256k1Pubkey,
       sequence: number,
       messages: readonly EncodeObject[],
-      gasPrice: GasPrice = this.defaultGasPrice,
+      gasPrice: GasPrice = this.getGasPrice(),
       memo?: string,
     ): Promise<StdFee> {
       // Get simulated response.

--- a/v4-client-js/src/clients/validator-client.ts
+++ b/v4-client-js/src/clients/validator-client.ts
@@ -3,7 +3,12 @@ import { Tendermint37Client } from '@cosmjs/tendermint-rpc';
 import Long from 'long';
 import protobuf from 'protobufjs';
 
-import { ValidatorConfig, BROADCAST_POLL_INTERVAL_MS, BROADCAST_TIMEOUT_MS } from './constants';
+import {
+  ValidatorConfig,
+  BROADCAST_POLL_INTERVAL_MS,
+  BROADCAST_TIMEOUT_MS,
+  SelectedGasDenom,
+} from './constants';
 import { Get } from './modules/get';
 import { Post } from './modules/post';
 import { TendermintClient } from './modules/tendermintClient';
@@ -53,6 +58,17 @@ export class ValidatorClient {
      */
   get post(): Post {
     return this._post!;
+  }
+
+  get selectedGasDenom(): SelectedGasDenom | undefined {
+    if (!this._post) return undefined;
+    return this._post.selectedGasDenom;
+  }
+
+  setSelectedGasDenom(gasDenom: SelectedGasDenom): void {
+    if (!this._post) throw new Error('Post module not initialized');
+
+    this._post.setSelectedGasDenom(gasDenom);
   }
 
   private async initialize(): Promise<void> {


### PR DESCRIPTION
- Expose setters to select different denom `gasPrice` for transactions within the Validator Client.
- Add native token faucet to FaucetClient