### PR TITLE
v1.1.11: Remove zeroFee for subaccount transfer, update MAX_NUMBER_SUBACCOUNTS

### DIFF
--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/composite-client.ts
+++ b/v4-client-js/src/clients/composite-client.ts
@@ -741,7 +741,7 @@ export class CompositeClient {
     return this.send(
       subaccount.wallet,
       () => msgs,
-      true,
+      false,
       undefined,
       memo,
     );

--- a/v4-client-js/src/clients/subaccount.ts
+++ b/v4-client-js/src/clients/subaccount.ts
@@ -1,3 +1,4 @@
+import { MAX_SUBACCOUNT_NUMBER } from './constants';
 import LocalWallet from './modules/local-wallet';
 
 export class SubaccountInfo {
@@ -6,8 +7,8 @@ export class SubaccountInfo {
     readonly subaccountNumber: number;
 
     constructor(wallet: LocalWallet, subaccountNumber: number = 0) {
-      if (subaccountNumber < 0 || subaccountNumber > 127) {
-        throw new Error('Subaccount number must be between 0 and 127');
+      if (subaccountNumber < 0 || subaccountNumber > MAX_SUBACCOUNT_NUMBER) {
+        throw new Error(`Subaccount number must be between 0 and ${MAX_SUBACCOUNT_NUMBER}`);
       }
       this.wallet = wallet;
       this.subaccountNumber = subaccountNumber;

--- a/v4-client-js/src/lib/constants.ts
+++ b/v4-client-js/src/lib/constants.ts
@@ -21,7 +21,7 @@ export const ZERO_FEE: StdFee = {
 
 // Validation
 export const MAX_UINT_32 = 4_294_967_295;
-export const MAX_SUBACCOUNT_NUMBER = 127;
+export const MAX_SUBACCOUNT_NUMBER = 128_000;
 
 export const DEFAULT_SEQUENCE: number = 0;
 


### PR DESCRIPTION
- Fix `transferToSubaccount` by removing zeroFee flag
- Update validation to account for new `MAX_NUMBER_SUBACCOUNTS`