### PR TITLE
fix url for withdrawing delegator rewards

### DIFF
--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.1.19",
+      "version": "1.1.20",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/constants.ts
+++ b/v4-client-js/src/clients/constants.ts
@@ -96,10 +96,12 @@ export const TYPE_URL_MSG_DEPOSIT_TO_SUBACCOUNT = '/dydxprotocol.sending.MsgDepo
 // x/staking
 export const TYPE_URL_MSG_DELEGATE = '/cosmos.staking.v1beta1.MsgDelegate';
 export const TYPE_URL_MSG_UNDELEGATE = '/cosmos.staking.v1beta1.MsgUndelegate';
-export const TYPE_URL_MSG_WITHDRAW_DELEGATOR_REWARD =
-  '/cosmos.staking.v1beta1.MsgWithdrawDelegatorReward';
 
-// ------------ Chain Constants ------------
+// x/distribution
+export const TYPE_URL_MSG_WITHDRAW_DELEGATOR_REWARD =
+  '/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward';
+
+  // ------------ Chain Constants ------------
 // The following are same across different networks / deployments.
 export const GOV_MODULE_ADDRESS = 'dydx10d07y265gmmuvt4z0w9aw880jnsr700jnmapky';
 export const DELAYMSG_MODULE_ADDRESS = 'dydx1mkkvp26dngu6n8rmalaxyp3gwkjuzztq5zx6tr';


### PR DESCRIPTION
was hitting `Unregistered type url: /cosmos.staking.v1beta1.MsgWithdrawDelegatorReward` in web, realized it was in `distribution` from doc [here](https://docs.rs/juno-rust-proto/latest/juno_rust_proto/cosmos/distribution/v1beta1/struct.MsgWithdrawDelegatorReward.html)
