### PR TITLE
feat: add parent subaccount queries

### DIFF
--- a/v4-client-js/__tests__/modules/client/AccountEndpoints.test.ts
+++ b/v4-client-js/__tests__/modules/client/AccountEndpoints.test.ts
@@ -56,8 +56,43 @@ describe('IndexerClient', () => {
       }
     });
 
+    it('Transfers ParentSubaccountNumber', async () => {
+      const response = await client.account.getParentSubaccountNumberTransfers(DYDX_TEST_ADDRESS, 0);
+      expect(response).not.toBeNull();
+      const transfers = response.transfers;
+      expect(transfers).not.toBeNull();
+      if (transfers.length > 0) {
+        const transfer = transfers[0];
+        expect(transfer).not.toBeNull();
+      }
+    });
+
     it('Transfers Pagination', async () => {
       const response = await client.account.getSubaccountTransfers(
+        DYDX_TEST_ADDRESS,
+        0,
+        1,
+        undefined,
+        undefined,
+        1,
+      );
+      expect(response).not.toBeNull();
+      const transfers = response.transfers;
+
+      expect(transfers).not.toBeNull();
+      if (transfers.length > 0) {
+        const transfer = transfers[0];
+        expect(transfer).not.toBeNull();
+
+        expect(response.totalResults).toBeGreaterThanOrEqual(1);
+      }
+
+      expect(response.pageSize).toStrictEqual(1);
+      expect(response.offset).toStrictEqual(0);
+    });
+
+    it('Transfers ParentSubaccountNumber Pagination', async () => {
+      const response = await client.account.getParentSubaccountNumberTransfers(
         DYDX_TEST_ADDRESS,
         0,
         1,
@@ -102,8 +137,44 @@ describe('IndexerClient', () => {
       }
     });
 
+    it('Fills ParentSubaccountNumber', async () => {
+      const response = await client.account.getParentSubaccountNumberFills(DYDX_TEST_ADDRESS, 0);
+      expect(response).not.toBeNull();
+      const fills = response.fills;
+      expect(fills).not.toBeNull();
+      if (fills.length > 0) {
+        const fill = fills[0];
+        expect(fill).not.toBeNull();
+      }
+    });
+
     it('Fills Pagination', async () => {
       const response = await client.account.getSubaccountFills(
+        DYDX_TEST_ADDRESS,
+        0,
+        undefined,
+        undefined,
+        1,
+        undefined,
+        undefined,
+        1,
+      );
+
+      expect(response).not.toBeNull();
+      const fills = response.fills;
+      expect(fills).not.toBeNull();
+      if (fills.length > 0) {
+        const fill = fills[0];
+        expect(fill).not.toBeNull();
+        expect(response.totalResults).toBeGreaterThanOrEqual(1);
+      }
+
+      expect(response.pageSize).toStrictEqual(1);
+      expect(response.offset).toStrictEqual(0);
+    });
+
+    it('Fills ParentSubaccountNumber Pagination', async () => {
+      const response = await client.account.getParentSubaccountNumberFills(
         DYDX_TEST_ADDRESS,
         0,
         undefined,

--- a/v4-client-js/src/clients/modules/account.ts
+++ b/v4-client-js/src/clients/modules/account.ts
@@ -73,6 +73,25 @@ export default class AccountClient extends RestClient {
     });
   }
 
+  async getParentSubaccountNumberTransfers(
+    address: string,
+    parentSubaccountNumber: number,
+    limit?: number | null,
+    createdBeforeOrAtHeight?: number | null,
+    createdBeforeOrAt?: string | null,
+    page?: number | null,
+  ): Promise<Data> {
+    const uri = '/v4/transfers/parentSubaccountNumber';
+    return this.get(uri, {
+      address,
+      parentSubaccountNumber,
+      limit,
+      createdBeforeOrAtHeight,
+      createdBeforeOrAt,
+      page,
+    });
+  }
+
   async getSubaccountOrders(
     address: string,
     subaccountNumber: number,
@@ -121,6 +140,29 @@ export default class AccountClient extends RestClient {
     return this.get(uri, {
       address,
       subaccountNumber,
+      ticker,
+      tickerType,
+      limit,
+      createdBeforeOrAtHeight,
+      createdBeforeOrAt,
+      page,
+    });
+  }
+
+  async getParentSubaccountNumberFills(
+    address: string,
+    parentSubaccountNumber: number,
+    ticker?: string | null,
+    tickerType: TickerType = TickerType.PERPETUAL,
+    limit?: number | null,
+    createdBeforeOrAtHeight?: number | null,
+    createdBeforeOrAt?: string | null,
+    page?: number | null,
+  ): Promise<Data> {
+    const uri = '/v4/fills/parentSubaccountNumber';
+    return this.get(uri, {
+      address,
+      parentSubaccountNumber,
       ticker,
       tickerType,
       limit,


### PR DESCRIPTION
This PR exposes two endpoints for fills and transfers related to the `v4/fills/parentSubaccountNumber` route