### PR TITLE
Adding createdBeforeOrAt param to getTrades API

### DIFF
--- a/v4-client-js/__tests__/modules/client/MarketsEndpoints.test.ts
+++ b/v4-client-js/__tests__/modules/client/MarketsEndpoints.test.ts
@@ -32,6 +32,7 @@ describe('IndexerClient', () => {
       const response = await client.markets.getPerpetualMarketTrades(
         MARKET_BTC_USD,
         undefined,
+        undefined,
         1,
         1,
       );

--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.1.24",
+      "version": "1.1.25",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/modules/markets.ts
+++ b/v4-client-js/src/clients/modules/markets.ts
@@ -19,12 +19,14 @@ export default class MarketsClient extends RestClient {
   async getPerpetualMarketTrades(
     market: string,
     startingBeforeOrAtHeight?: number | null,
+    startingBeforeOrAt?: string | null,
     limit?: number | null,
     page?: number | null,
   ): Promise<Data> {
     const uri = `/v4/trades/perpetualMarket/${market}`;
     return this.get(uri, {
       createdBeforeOrAtHeight: startingBeforeOrAtHeight,
+      createdBeforeOrAt: startingBeforeOrAt,
       limit,
       page,
     });


### PR DESCRIPTION
Adds the `createdBeforeOrAt` param to the JS client's GetTrades function.