### PR TITLE
fix: fix rounding error on certain values in calculateSubticks

### DIFF
--- a/v4-client-js/__tests__/lib/helpers.test.ts
+++ b/v4-client-js/__tests__/lib/helpers.test.ts
@@ -2,8 +2,16 @@ import { PartialTransactionOptions, TransactionOptions } from '../../src';
 import { DEFAULT_SEQUENCE } from '../../src/lib/constants';
 import { convertPartialTransactionOptionsToFull, stripHexPrefix } from '../../src/lib/helpers';
 import { defaultTransactionOptions } from '../helpers/constants';
+import { calculateSubticks } from '../../src/clients/helpers/chain-helpers';
+import Long from 'long';
 
 describe('helpers', () => {
+  describe('calculateSubticks', () => {
+    it('test test', () => {
+      expect(calculateSubticks(8.45, -7, -9, 1000000)).toEqual(new Long(845_000_000));
+    });
+  });
+  
   describe('convertPartialTransactionOptionsToFull', () =>
     it.each([
       [

--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.1.22",
+      "version": "1.1.23",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.23",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.1.23",
+      "version": "1.2.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.2.0",
+  "version": "1.1.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.2.0",
+      "version": "1.1.24",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.23",
+  "version": "1.2.0",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.2.0",
+  "version": "1.1.24",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/helpers/chain-helpers.ts
+++ b/v4-client-js/src/clients/helpers/chain-helpers.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js';
 import Long from 'long';
 
 import { OrderType, OrderSide, OrderTimeInForce, OrderExecution } from '../constants';
@@ -28,8 +29,8 @@ export function calculateSubticks(
 ): Long {
   const QUOTE_QUANTUMS_ATOMIC_RESOLUTION = -6;
   const exponent = atomicResolution - quantumConversionExponent - QUOTE_QUANTUMS_ATOMIC_RESOLUTION;
-  const rawSubticks = price * 10 ** exponent;
-  const subticks = round(rawSubticks, subticksPerTick);
+  const rawSubticks = BigNumber(price).times(BigNumber(10).exponentiatedBy(exponent));
+  const subticks = round(rawSubticks.toNumber(), subticksPerTick);
   const result = Math.max(subticks, subticksPerTick);
   return Long.fromNumber(result);
 }

--- a/v4-client-js/src/clients/helpers/chain-helpers.ts
+++ b/v4-client-js/src/clients/helpers/chain-helpers.ts
@@ -29,7 +29,7 @@ export function calculateSubticks(
 ): Long {
   const QUOTE_QUANTUMS_ATOMIC_RESOLUTION = -6;
   const exponent = atomicResolution - quantumConversionExponent - QUOTE_QUANTUMS_ATOMIC_RESOLUTION;
-  const rawSubticks = BigNumber(price).times(BigNumber(10).exponentiatedBy(exponent));
+  const rawSubticks = BigNumber(price).times(BigNumber(10).pow(exponent));
   const subticks = round(rawSubticks.toNumber(), subticksPerTick);
   const result = Math.max(subticks, subticksPerTick);
   return Long.fromNumber(result);


### PR DESCRIPTION
there was a javascript/typescript precision error with the exponentiation causing some trade input values to be rounded incorrectly (notably if you try to input 8.45 on the TIA market, you'll always get back a trade at 8.44). Resolved by using BigNumber library. Tested by verifying new test fails before changes; passes after changes. (Test mock data is equivalent to inputs from the TIA market)