### PR TITLE
Add onError callback to socket client and readyState helpers

### DIFF
--- a/v4-client-js/examples/websocket_example.ts
+++ b/v4-client-js/examples/websocket_example.ts
@@ -34,6 +34,9 @@ function test(): void {
         }
       }
     },
+    (event) => {
+      console.error('Encountered error:', event.message);
+    },
   );
   mySocket.connect();
 }

--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.1.24",
+      "version": "1.1.25",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {


### PR DESCRIPTION
- Adding onError callback allows users to handle errors.
- readyState helper functions allow users to determine the current state of the underlying websocket.