### PR TITLE
feat: register msgDepositForBurnWithCaller type

### DIFF
--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.1.25",
+      "version": "1.1.26",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/noble-client.ts
+++ b/v4-client-js/src/clients/noble-client.ts
@@ -10,7 +10,7 @@ import {
 } from '@cosmjs/stargate';
 
 import { GAS_MULTIPLIER } from './constants';
-import { MsgDepositForBurn } from './lib/cctpProto';
+import { MsgDepositForBurn, MsgDepositForBurnWithCaller } from './lib/cctpProto';
 import LocalWallet from './modules/local-wallet';
 
 export class NobleClient {
@@ -39,6 +39,7 @@ export class NobleClient {
       {
         registry: new Registry([
           ['/circle.cctp.v1.MsgDepositForBurn', MsgDepositForBurn],
+          ['/circle.cctp.v1.MsgDepositForBurnWithCaller', MsgDepositForBurnWithCaller],
           ...defaultRegistryTypes,
         ]),
       },


### PR DESCRIPTION
adds `'/circle.cctp.v1.MsgDepositForBurnWithCaller'` so we can use skip's smart relay functionality