### PR TITLE
Fix the historical pnls indexer query

### DIFF
--- a/v4-client-js/__tests__/modules/client/AccountEndpoints.test.ts
+++ b/v4-client-js/__tests__/modules/client/AccountEndpoints.test.ts
@@ -215,6 +215,8 @@ describe('IndexerClient', () => {
         0,
         undefined,
         undefined,
+        undefined,
+        undefined,
         1,
         1,
       );

--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.1.27",
+      "version": "1.1.28",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/modules/account.ts
+++ b/v4-client-js/src/clients/modules/account.ts
@@ -175,8 +175,10 @@ export default class AccountClient extends RestClient {
   async getSubaccountHistoricalPNLs(
     address: string,
     subaccountNumber: number,
-    effectiveBeforeOrAt?: string | null,
-    effectiveAtOrAfter?: string | null,
+    createdBeforeOrAtHeight?: number | null,
+    createdBeforeOrAt?: string | null,
+    createdOnOrAfterHeight?: number | null,
+    createdOnOrAfter?: string | null,
     limit?: number | null,
     page?: number | null,
   ): Promise<Data> {
@@ -184,8 +186,10 @@ export default class AccountClient extends RestClient {
     return this.get(uri, {
       address,
       subaccountNumber,
-      effectiveBeforeOrAt,
-      effectiveAtOrAfter,
+      createdBeforeOrAtHeight,
+      createdBeforeOrAt,
+      createdOnOrAfterHeight,
+      createdOnOrAfter,
       limit,
       page,
     });


### PR DESCRIPTION
The function was originally using param names like effectiveBeforeOrAt but param names are expected to be createdBeforeOrAt and createdOnOrAfter instead. Also, the function was missing the block height versions of the createdBeforeOrAt and createdOnOrAfter query params, so I added those in too.