### PR TITLE
fix: correct gas price for noble [OTE-565]

### DIFF
--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.1.26",
+      "version": "1.1.27",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/noble-client.ts
+++ b/v4-client-js/src/clients/noble-client.ts
@@ -67,7 +67,7 @@ export class NobleClient {
 
   async send(
     messages: EncodeObject[],
-    gasPrice: GasPrice = GasPrice.fromString('0.025uusdc'),
+    gasPrice: GasPrice = GasPrice.fromString('0.1uusdc'),
     memo?: string,
   ): Promise<DeliverTxResponse> {
     if (!this.stargateClient) {
@@ -90,7 +90,7 @@ export class NobleClient {
 
   async simulateTransaction(
     messages: readonly EncodeObject[],
-    gasPrice: GasPrice = GasPrice.fromString('0.025uusdc'),
+    gasPrice: GasPrice = GasPrice.fromString('0.1uusdc'),
     memo?: string,
   ): Promise<StdFee> {
     if (!this.stargateClient) {


### PR DESCRIPTION
set correct gas price for noble. it should be 0.1uusdc and not 0.025uusdc.

resolves linear ticket OTE-565 fix smart relay https://linear.app/dydx/issue/OTE-565/[client-js]-fix-smart-relay
