### PR TITLE
fix: enable local builds for OTE-570

### DIFF
--- a/v4-client-js/.gitignore
+++ b/v4-client-js/.gitignore
@@ -24,3 +24,6 @@ npm-debug.log
 
 # IDE
 .idea
+
+# Packed tgz for local dev
+*.tgz

--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.1.27",
+      "version": "1.1.28",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/tsconfig.json
+++ b/v4-client-js/tsconfig.json
@@ -11,6 +11,7 @@
   ],
   "compilerOptions": {
     "outDir": "build",
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "skipLibCheck": true
   }
 }

--- a/v4-client-js/tsconfig.json
+++ b/v4-client-js/tsconfig.json
@@ -11,7 +11,6 @@
   ],
   "compilerOptions": {
     "outDir": "build",
-    "noFallthroughCasesInSwitch": false,
-    "skipLibCheck": true
+    "noFallthroughCasesInSwitch": false
   }
 }


### PR DESCRIPTION
[to enable local installation of v4-clients](https://linear.app/dydx/issue/OTE-570/[v4-web]-install-local-client-js), we need to make sure our vite config ignores node modules. this will allow us to develop on v4-clients while experiencing the effects on v4-web directly