### PR TITLE
Fix incorrect native function name in getCurrentUnstaking

### DIFF
--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.1.28",
+      "version": "1.1.29",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/native.ts
+++ b/v4-client-js/src/clients/native.ts
@@ -968,7 +968,7 @@ export async function getDelegatorDelegations(payload: string): Promise<string> 
   }
 }
 
-export async function getDelegatorUnbondingDelegations(payload: string): Promise<string> {
+export async function getCurrentUnstaking(payload: string): Promise<string> {
   try {
     const client = globalThis.client;
     if (client === undefined) {


### PR DESCRIPTION
Otherwise, the abacus call from mobile would fail.