### PR TITLE
Fix candle subscription in websocket_example.py

### DIFF
--- a/v4-client-py-v2/examples/websocket_example.py
+++ b/v4-client-py-v2/examples/websocket_example.py
@@ -12,7 +12,7 @@ def handle_message(ws: IndexerSocket, message: dict):
         ws.markets.subscribe()
         ws.order_book.subscribe(ETH_USD)
         ws.trades.subscribe(ETH_USD)
-        ws.candles.subscribe(ETH_USD, CandlesResolution.FIFTEEN_MINUTES)
+        ws.candles.subscribe(ETH_USD, CandlesResolution.FIFTEEN_MINUTES.value)
         ws.subaccounts.subscribe(TEST_ADDRESS, 0)
     print(message)
 


### PR DESCRIPTION
Add .value access at resolution enum in order to prevent 'Invalid subscription id for channel: (v4_candles-ETH-USD/CandlesResolution.FIFTEEN_MINUTES)'-error.