### PR TITLE
fix: fix rounding error on order sizes

### DIFF
--- a/v4-client-js/README.md
+++ b/v4-client-js/README.md
@@ -27,8 +27,8 @@ nvm alias default $(nvm version) # optional
 You can run the following commands to ensure that you are running the correct `node` and `npm` versions.
 
 ```
-node -v # expected: v18.x.x (should match .nvmrc)
-npm -v  # expected: 8.x.x
+node -v # expected: v20.x.x (should match .nvmrc)
+npm -v  # expected: 10.x.x
 ```
 
 ### 1. Clone or fork the V4 clients repo

--- a/v4-client-js/__tests__/lib/helpers.test.ts
+++ b/v4-client-js/__tests__/lib/helpers.test.ts
@@ -2,13 +2,19 @@ import { PartialTransactionOptions, TransactionOptions } from '../../src';
 import { DEFAULT_SEQUENCE } from '../../src/lib/constants';
 import { convertPartialTransactionOptionsToFull, stripHexPrefix } from '../../src/lib/helpers';
 import { defaultTransactionOptions } from '../helpers/constants';
-import { calculateSubticks } from '../../src/clients/helpers/chain-helpers';
+import { calculateSubticks, calculateQuantums } from '../../src/clients/helpers/chain-helpers';
 import Long from 'long';
 
 describe('helpers', () => {
   describe('calculateSubticks', () => {
-    it('test test', () => {
+    it('correctly handles decimals', () => {
       expect(calculateSubticks(8.45, -7, -9, 1000000)).toEqual(new Long(845_000_000));
+    });
+  });
+
+  describe('calculateQuantums', () => {
+    it('correctly handles decimals', () => {
+      expect(calculateQuantums(0.0003, -10, 1000000)).toEqual(new Long(3_000_000));
     });
   });
   

--- a/v4-client-js/src/clients/helpers/chain-helpers.ts
+++ b/v4-client-js/src/clients/helpers/chain-helpers.ts
@@ -6,7 +6,7 @@ import { Order_ConditionType, Order_Side, Order_TimeInForce } from '../modules/p
 import { OrderFlags } from '../types';
 
 export function round(input: number, base: number): number {
-  return Math.floor(input / base) * base;
+  return BigNumber(input).div(BigNumber(base)).integerValue(BigNumber.ROUND_FLOOR).times(BigNumber(base)).toNumber();
 }
 
 export function calculateQuantums(
@@ -14,8 +14,8 @@ export function calculateQuantums(
   atomicResolution: number,
   stepBaseQuantums: number,
 ): Long {
-  const rawQuantums = size * 10 ** (-1 * atomicResolution);
-  const quantums = round(rawQuantums, stepBaseQuantums);
+  const rawQuantums = BigNumber(size).times(BigNumber(10).pow(BigNumber(atomicResolution).negated()));
+  const quantums = round(rawQuantums.toNumber(), stepBaseQuantums);
   // stepBaseQuantums functions as minimum order size
   const result = Math.max(quantums, stepBaseQuantums);
   return Long.fromNumber(result);


### PR DESCRIPTION
by using BigNumber, instead of hitting precision errors with Javascript.

Test case added reflects the 0.0003 size on BTC that used to round to 0.0002; verified that the test fails before the change and passes after the change.