### PR TITLE
fix: duplicate v4-proto dep into devDep

### DIFF
--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -55,6 +55,7 @@
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",
     "@dydxprotocol/node-service-base-dev": "^0.2.6",
+    "@dydxprotocol/v4-proto": "6.0.1",
     "@protobufs/cosmos": "^0.0.11",
     "@protobufs/gogoproto": "^0.0.10",
     "@semantic-release/changelog": "^6.0.3",


### PR DESCRIPTION
Was running into an issue where everytime I tried to commit with an updated v4-clients, I got 
```Cannot find module '@dydxprotocol/v4-proto/...``` 

Figured out from [here](https://dev.to/jody/a-tip-on-using-peer-dependencies-with-typescript-2bji) that this is expected from moving proto into peerDependencies. Managed to get things working (using jeremy's nifty lil local install script) by duplicating into `devDependencies` which I think should be adequate (as opposed to moving it into `dependencies` but someone lmk if I'm wrong