### PR TITLE
fix: package node modules

### DIFF
--- a/.github/workflows/js-publish.yml
+++ b/.github/workflows/js-publish.yml
@@ -42,6 +42,6 @@ jobs:
       - name: Run semantic-release
         run: npm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_WRITE }}
+
 

--- a/v4-client-js/.npmignore
+++ b/v4-client-js/.npmignore
@@ -1,0 +1,1 @@
+!build/node_modules/@dydxprotocol/v4-proto/**/**.ts

--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.3.3",
+      "version": "1.3.15",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",


### PR DESCRIPTION
semantic-release is smart enough to know to **not** pack any node modules, so we have to purposefully override via `.npmignore` 


However, i accidentally created.... version 3.16. We'll need @BrendanChou to remove it https://www.npmjs.com/package/@dydxprotocol/v4-client-js?activeTab=versions (sorry 🙇 )