### PR TITLE
feat: add function to prepopulate account number cache

### DIFF
--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/composite-client.ts
+++ b/v4-client-js/src/clients/composite-client.ts
@@ -109,9 +109,9 @@ export class CompositeClient {
     this._validatorClient.setSelectedGasDenom(gasDenom);
   }
 
-  populateAccountNumberCache(address: string): Promise<void> {
+  async populateAccountNumberCache(address: string): Promise<void> {
     if (!this._validatorClient) throw new Error('Validator client not initialized');
-    return this._validatorClient.populateAccountNumberCache(address);
+    await this._validatorClient.populateAccountNumberCache(address);
   }
 
   /**

--- a/v4-client-js/src/clients/composite-client.ts
+++ b/v4-client-js/src/clients/composite-client.ts
@@ -109,6 +109,11 @@ export class CompositeClient {
     this._validatorClient.setSelectedGasDenom(gasDenom);
   }
 
+  populateAccountNumberCache(address: string): Promise<void> {
+    if (!this._validatorClient) throw new Error('Validator client not initialized');
+    return this._validatorClient.populateAccountNumberCache(address);
+  }
+
   /**
    * @description Sign a list of messages with a wallet.
    * the calling function is responsible for creating the messages.

--- a/v4-client-js/src/clients/modules/post.ts
+++ b/v4-client-js/src/clients/modules/post.ts
@@ -76,6 +76,18 @@ export class Post {
     );
   }
 
+  /**
+   * @description Retrieves the account number for the given wallet address and populates the accountNumberCache.
+   * The account number is required for txOptions when signing a transaction.
+   * Pre-populating the cache avoids a round-trip request during the first transaction creation in the session, preventing it from being a performance blocker.
+   */
+  public async populateAccountNumberCache(address: string): Promise<void> {
+    if (this.accountNumberCache.has(address)) return;
+
+    const account = await this.get.getAccount(address);
+    this.accountNumberCache.set(address, account);
+  }
+
   setSelectedGasDenom(selectedGasDenom: SelectedGasDenom): void {
     this.selectedGasDenom = selectedGasDenom;
   }

--- a/v4-client-js/src/clients/validator-client.ts
+++ b/v4-client-js/src/clients/validator-client.ts
@@ -73,10 +73,9 @@ export class ValidatorClient {
   /**
    * @description populate account number cache in the Post module for performance.
    */
-  populateAccountNumberCache(address: string): Promise<void> {
+  async populateAccountNumberCache(address: string): Promise<void> {
     if (!this._post) throw new Error('Post module not initialized');
-
-    return this._post.populateAccountNumberCache(address);
+    await this._post.populateAccountNumberCache(address);
   }
 
   private async initialize(): Promise<void> {

--- a/v4-client-js/src/clients/validator-client.ts
+++ b/v4-client-js/src/clients/validator-client.ts
@@ -69,6 +69,16 @@ export class ValidatorClient {
     this._post.setSelectedGasDenom(gasDenom);
   }
 
+
+  /**
+   * @description populate account number cache in the Post module for performance.
+   */
+  populateAccountNumberCache(address: string): Promise<void> {
+    if (!this._post) throw new Error('Post module not initialized');
+
+    return this._post.populateAccountNumberCache(address);
+  }
+
   private async initialize(): Promise<void> {
     const tendermint37Client: Tendermint37Client = await Tendermint37Client.connect(
       this.config.restEndpoint,


### PR DESCRIPTION
motivation:
- in FE, when creating the first transaction (e.g. placing a short term order after web app starts), we need to query account as part of the tx to get the account number before sending the place order message.
- we can actually pre populate the account number cache earlier (i.e. app starts / clients initialized with address) so it doesn't have to be a blocker
- once timestamp nonce is enabled, we will no longer need to fetch account seq number, so this will also help eliminate the round trip time blocker when placing a stateful order first

change:
- add `populateAccountNumberCache` function

testing:
- tested locally / integration with FE app https://github.com/dydxprotocol/v4-web/pull/1062
- backwards compatible