### PR TITLE
feat: support for timestamp nonce

### DIFF
--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/src/index.js",
   "scripts": {

--- a/v4-client-js/src/clients/constants.ts
+++ b/v4-client-js/src/clients/constants.ts
@@ -220,6 +220,7 @@ export class ValidatorConfig {
   public denoms: DenomConfig;
   public broadcastOptions?: BroadcastOptions;
   public defaultClientMemo?: string;
+  public useTimestampNonce?: boolean;
 
   constructor(
     restEndpoint: string,
@@ -227,6 +228,7 @@ export class ValidatorConfig {
     denoms: DenomConfig,
     broadcastOptions?: BroadcastOptions,
     defaultClientMemo?: string,
+    useTimestampNonce?: boolean,
   ) {
     this.restEndpoint = restEndpoint?.endsWith('/') ? restEndpoint.slice(0, -1) : restEndpoint;
     this.chainId = chainId;
@@ -234,6 +236,7 @@ export class ValidatorConfig {
     this.denoms = denoms;
     this.broadcastOptions = broadcastOptions;
     this.defaultClientMemo = defaultClientMemo;
+    this.useTimestampNonce = useTimestampNonce;
   }
 }
 

--- a/v4-client-js/src/clients/modules/post.ts
+++ b/v4-client-js/src/clients/modules/post.ts
@@ -116,6 +116,7 @@ export class Post {
     account?: () => Promise<Account>,
   ): Promise<StdFee> {
     let msgs: EncodeObject[];
+    // protocol expects timestamp nonce in UTC milliseconds, which is the unit returned by Date.now()
     let sequence = Date.now();
 
     if (this.useTimestampNonce) {
@@ -235,6 +236,7 @@ export class Post {
     gasPrice: GasPrice = this.getGasPrice(),
     memo?: string,
   ): Promise<Uint8Array> {
+    // protocol expects timestamp nonce in UTC milliseconds, which is the unit returned by Date.now()
     const sequence = this.useTimestampNonce ? Date.now() : account.sequence;
     // Simulate transaction if no fee is specified.
     const fee: StdFee = zeroFee
@@ -262,7 +264,7 @@ export class Post {
   public async account(address: string, orderFlags?: OrderFlags): Promise<Account> {
     if (orderFlags === OrderFlags.SHORT_TERM || this.useTimestampNonce) {
       if (this.accountNumberCache.has(address)) {
-        // For SHORT_TERM orders and when timestamp nonce is enabled, the sequence doesn't matter
+        // If order is SHORT_TERM or if timestamp nonce is enabled, the sequence doesn't matter
         return this.accountNumberCache.get(address)!;
       }
     }

--- a/v4-client-js/src/clients/modules/post.ts
+++ b/v4-client-js/src/clients/modules/post.ts
@@ -55,9 +55,10 @@ export class Post {
   public readonly defaultGasPrice: GasPrice;
   public readonly defaultDydxGasPrice: GasPrice;
 
+  public useTimestampNonce: boolean = false;
   private accountNumberCache: Map<string, Account> = new Map();
 
-  constructor(get: Get, chainId: string, denoms: DenomConfig, defaultClientMemo?: string) {
+  constructor(get: Get, chainId: string, denoms: DenomConfig, defaultClientMemo?: string, useTimestampNonce?: boolean) {
     this.get = get;
     this.chainId = chainId;
     this.registry = generateRegistry();
@@ -74,6 +75,7 @@ export class Post {
           : denoms.CHAINTOKEN_DENOM
       }`,
     );
+    if (useTimestampNonce === true) this.useTimestampNonce = useTimestampNonce;
   }
 
   /**
@@ -113,14 +115,22 @@ export class Post {
     memo?: string,
     account?: () => Promise<Account>,
   ): Promise<StdFee> {
-    const msgsPromise = messaging();
-    const accountPromise = account ? await account() : this.account(wallet.address!);
-    const msgsAndAccount = await Promise.all([msgsPromise, accountPromise]);
-    const msgs = msgsAndAccount[0];
+    let msgs: EncodeObject[];
+    let sequence = Date.now();
+
+    if (this.useTimestampNonce) {
+      msgs = await messaging();
+    } else {
+      const msgsPromise = messaging();
+      const accountPromise = account ? await account() : this.account(wallet.address!);
+      const msgsAndAccount = await Promise.all([msgsPromise, accountPromise]);
+      msgs = msgsAndAccount[0];
+      sequence = msgsAndAccount[1].sequence;
+    }
 
     return this.simulateTransaction(
       wallet.pubKey!,
-      msgsAndAccount[1].sequence,
+      sequence,
       msgs,
       gasPrice,
       memo,
@@ -225,16 +235,17 @@ export class Post {
     gasPrice: GasPrice = this.getGasPrice(),
     memo?: string,
   ): Promise<Uint8Array> {
+    const sequence = this.useTimestampNonce ? Date.now() : account.sequence;
     // Simulate transaction if no fee is specified.
     const fee: StdFee = zeroFee
       ? {
           amount: [],
           gas: '1000000',
         }
-      : await this.simulateTransaction(wallet.pubKey!, account.sequence, messages, gasPrice, memo);
+      : await this.simulateTransaction(wallet.pubKey!, sequence, messages, gasPrice, memo);
 
     const txOptions: TransactionOptions = {
-      sequence: account.sequence,
+      sequence,
       accountNumber: account.accountNumber,
       chainId: this.chainId,
     };
@@ -246,11 +257,12 @@ export class Post {
    * @description Retrieve an account structure for transactions.
    * For short term orders, the sequence doesn't matter. Use cached if available.
    * For long term and conditional orders, a round trip to validator must be made.
+   * when timestamp nonce is supported, no need to fetch account sequence number
    */
   public async account(address: string, orderFlags?: OrderFlags): Promise<Account> {
-    if (orderFlags === OrderFlags.SHORT_TERM) {
+    if (orderFlags === OrderFlags.SHORT_TERM || this.useTimestampNonce) {
       if (this.accountNumberCache.has(address)) {
-        // For SHORT_TERM orders, the sequence doesn't matter
+        // For SHORT_TERM orders and when timestamp nonce is enabled, the sequence doesn't matter
         return this.accountNumberCache.get(address)!;
       }
     }

--- a/v4-client-js/src/clients/validator-client.ts
+++ b/v4-client-js/src/clients/validator-client.ts
@@ -97,6 +97,7 @@ export class ValidatorClient {
       this.config.chainId,
       this.config.denoms,
       this.config.defaultClientMemo,
+      this.config.useTimestampNonce,
     );
   }
 }


### PR DESCRIPTION
- account sequence number can soon be replaced by timestamp
- this eliminates the need to to fetch account sequence number from account as part of tx options
- adding a flag / config param since this isn't completely out yet

testing:
- tested locally / breakpoints that transactions work, and no unnecessary fetch to account for placing stateful orders