### PR TITLE
chore: Change Rust proto dep/client crate names, license reference

### DIFF
--- a/v4-client-rs/Cargo.toml
+++ b/v4-client-rs/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-license = "AGPL-3.0"
+license = "LicenseRef-dYdX-Custom"
 
 [workspace.dependencies]
 anyhow = "1"
@@ -17,4 +17,4 @@ derive_more = { version = "1", features = ["full"] }
 log = "0.4"
 thiserror = "1"
 tokio = { version = "1.39", features = ["full"] }
-v4-proto-rs = { git = "https://github.com/therustmonk/v4-chain", rev = "a6265bbf4cd9812382a89d32c9304c08551f7bae" }
+dydx-proto = "0.1.0"

--- a/v4-client-rs/README.md
+++ b/v4-client-rs/README.md
@@ -14,7 +14,7 @@ The following features are implemented:
 To add the crate to your project, use the command:
 
 ```sh
-cargo add dydx-v4-rust
+cargo add dydx
 ```
 
 ## Development
@@ -54,7 +54,7 @@ cargo deny check licenses advisories sources
 To generate the documentation, use the command
 
 ```sh
-cargo doc -p dydx-v4-rust
+cargo doc -p dydx
 ```
 
 ## Acknowledgements

--- a/v4-client-rs/client/Cargo.toml
+++ b/v4-client-rs/client/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
-name = "dydx-v4-rust"
+name = "dydx"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 
 description = "dYdX v4 asynchronous client."
-homepage = "https://github.com/dydxprotocol/v4-clients/v4-client-rs"
-repository = "https://github.com/dydxprotocol/v4-clients/v4-clients-rs"
+repository = "https://github.com/dydxprotocol/v4-clients/v4-client-rs"
 readme = "README.md"
 
 # https://crates.io/categories
@@ -47,7 +46,7 @@ tokio.workspace = true
 tokio-tungstenite = { version = "0.23", features = ["native-tls"] }
 toml = "0.8"
 tower = "0.4"
-v4-proto-rs.workspace = true
+dydx-proto.workspace = true
 
 # Telemetry
 metrics = { version = "0.23", optional = true }

--- a/v4-client-rs/client/examples/account_endpoint.rs
+++ b/v4-client-rs/client/examples/account_endpoint.rs
@@ -1,13 +1,13 @@
 mod support;
 
 use anyhow::{Error, Result};
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::indexer::{
+use dydx::config::ClientConfig;
+use dydx::indexer::{
     GetAggregationsOpts, GetFillsOpts, GetHistoricalPnlOpts, GetTradingRewardsOpts,
     GetTransfersOpts, IndexerClient, ListOrdersOpts, ListPositionsOpts, MarketType, OrderSide,
     PerpetualPositionStatus, Ticker, TradingRewardAggregationPeriod,
 };
-use dydx_v4_rust::node::Wallet;
+use dydx::node::Wallet;
 use support::constants::TEST_MNEMONIC;
 
 pub struct Rester {

--- a/v4-client-rs/client/examples/batch_cancel_orders.rs
+++ b/v4-client-rs/client/examples/batch_cancel_orders.rs
@@ -1,16 +1,14 @@
 mod support;
 use anyhow::{Error, Result};
 use bigdecimal::BigDecimal;
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::indexer::{ClientId, IndexerClient};
-use dydx_v4_rust::node::{
-    NodeClient, OrderBuilder, OrderSide, Wallet, SHORT_TERM_ORDER_MAXIMUM_LIFETIME,
-};
+use dydx::config::ClientConfig;
+use dydx::indexer::{ClientId, IndexerClient};
+use dydx::node::{NodeClient, OrderBuilder, OrderSide, Wallet, SHORT_TERM_ORDER_MAXIMUM_LIFETIME};
+use dydx_proto::dydxprotocol::clob::{order::TimeInForce, OrderBatch};
 use rand::thread_rng;
 use std::str::FromStr;
 use support::constants::TEST_MNEMONIC;
 use tokio::time::{sleep, Duration};
-use v4_proto_rs::dydxprotocol::clob::{order::TimeInForce, OrderBatch};
 
 const N_ORDERS: usize = 6;
 

--- a/v4-client-rs/client/examples/bot_basic_adder.rs
+++ b/v4-client-rs/client/examples/bot_basic_adder.rs
@@ -2,12 +2,12 @@ mod support;
 
 use anyhow::{anyhow as err, Error, Result};
 use bigdecimal::{BigDecimal, One, Signed};
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::indexer::{
+use dydx::config::ClientConfig;
+use dydx::indexer::{
     AnyId, Feed, IndexerClient, ListPerpetualMarketsOpts, PerpetualMarket, Price, Quantity,
     SubaccountsMessage, Ticker, TradesMessage,
 };
-use dydx_v4_rust::node::{Account, NodeClient, OrderBuilder, OrderId, OrderSide, Wallet};
+use dydx::node::{Account, NodeClient, OrderBuilder, OrderId, OrderSide, Wallet};
 use std::str::FromStr;
 use support::constants::TEST_MNEMONIC;
 use support::order_book::LiveOrderBook;

--- a/v4-client-rs/client/examples/bot_trend_follower.rs
+++ b/v4-client-rs/client/examples/bot_trend_follower.rs
@@ -2,12 +2,12 @@ mod support;
 
 use anyhow::{anyhow as err, Error, Result};
 use chrono::{TimeDelta, Utc};
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::indexer::{
+use dydx::config::ClientConfig;
+use dydx::indexer::{
     CandleResolution, ClientId, Feed, GetCandlesOpts, IndexerClient, ListPerpetualMarketsOpts,
     PerpetualMarket, Price, Quantity, Subaccount, SubaccountsMessage, Ticker, TradesMessage,
 };
-use dydx_v4_rust::node::{
+use dydx::node::{
     Account, NodeClient, OrderBuilder, OrderId, OrderSide, Wallet,
     SHORT_TERM_ORDER_MAXIMUM_LIFETIME,
 };

--- a/v4-client-rs/client/examples/cancel_order.rs
+++ b/v4-client-rs/client/examples/cancel_order.rs
@@ -1,11 +1,11 @@
 mod support;
 use anyhow::{Error, Result};
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::indexer::{AnyId, IndexerClient, Ticker};
-use dydx_v4_rust::node::{NodeClient, OrderBuilder, OrderSide, Wallet};
+use dydx::config::ClientConfig;
+use dydx::indexer::{AnyId, IndexerClient, Ticker};
+use dydx::node::{NodeClient, OrderBuilder, OrderSide, Wallet};
+use dydx_proto::dydxprotocol::clob::order::TimeInForce;
 use support::constants::TEST_MNEMONIC;
 use tokio::time::{sleep, Duration};
-use v4_proto_rs::dydxprotocol::clob::order::TimeInForce;
 
 const ETH_USD_TICKER: &str = "ETH-USD";
 

--- a/v4-client-rs/client/examples/close_all_positions.rs
+++ b/v4-client-rs/client/examples/close_all_positions.rs
@@ -1,11 +1,11 @@
 mod support;
 use anyhow::{Error, Result};
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::indexer::{
+use dydx::config::ClientConfig;
+use dydx::indexer::{
     ClientId, IndexerClient, ListPositionsOpts,
     PerpetualPositionResponseObject as PerpetualPosition, PerpetualPositionStatus, Subaccount,
 };
-use dydx_v4_rust::node::{NodeClient, Wallet};
+use dydx::node::{NodeClient, Wallet};
 use support::constants::TEST_MNEMONIC;
 
 pub struct OrderPlacer {

--- a/v4-client-rs/client/examples/close_position.rs
+++ b/v4-client-rs/client/examples/close_position.rs
@@ -1,13 +1,13 @@
 mod support;
 use anyhow::{Error, Result};
 use bigdecimal::BigDecimal;
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::indexer::{
+use dydx::config::ClientConfig;
+use dydx::indexer::{
     ClientId, IndexerClient, ListPositionsOpts,
     PerpetualPositionResponseObject as PerpetualPosition, PerpetualPositionStatus, Subaccount,
     Ticker,
 };
-use dydx_v4_rust::node::{NodeClient, Wallet};
+use dydx::node::{NodeClient, Wallet};
 use std::str::FromStr;
 use support::constants::TEST_MNEMONIC;
 use tokio::time::{sleep, Duration};

--- a/v4-client-rs/client/examples/deposit.rs
+++ b/v4-client-rs/client/examples/deposit.rs
@@ -1,7 +1,7 @@
 mod support;
 use anyhow::{Error, Result};
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::node::{NodeClient, Wallet};
+use dydx::config::ClientConfig;
+use dydx::node::{NodeClient, Wallet};
 use support::constants::TEST_MNEMONIC;
 
 pub struct Transferor {

--- a/v4-client-rs/client/examples/faucet_endpoint.rs
+++ b/v4-client-rs/client/examples/faucet_endpoint.rs
@@ -5,10 +5,10 @@ use anyhow::Result;
 mod faucet_endpoint_example {
     use super::support::constants::TEST_MNEMONIC;
     use anyhow::{anyhow as err, Error, Result};
-    use dydx_v4_rust::config::ClientConfig;
-    use dydx_v4_rust::faucet::FaucetClient;
-    use dydx_v4_rust::indexer::Usdc;
-    use dydx_v4_rust::node::Wallet;
+    use dydx::config::ClientConfig;
+    use dydx::faucet::FaucetClient;
+    use dydx::indexer::Usdc;
+    use dydx::node::Wallet;
     pub struct FaucetRequester {
         faucet: FaucetClient,
         wallet: Wallet,

--- a/v4-client-rs/client/examples/live_price.rs
+++ b/v4-client-rs/client/examples/live_price.rs
@@ -1,8 +1,8 @@
 mod support;
 use anyhow::{Error, Result};
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::indexer::{Feed, IndexerClient, MarketsMessage, Ticker};
-use dydx_v4_rust::node::{OrderBuilder, Wallet};
+use dydx::config::ClientConfig;
+use dydx::indexer::{Feed, IndexerClient, MarketsMessage, Ticker};
+use dydx::node::{OrderBuilder, Wallet};
 use support::constants::TEST_MNEMONIC;
 
 pub struct Feeder {

--- a/v4-client-rs/client/examples/market_endpoint.rs
+++ b/v4-client-rs/client/examples/market_endpoint.rs
@@ -1,6 +1,6 @@
 use anyhow::{Error, Result};
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::indexer::{
+use dydx::config::ClientConfig;
+use dydx::indexer::{
     CandleResolution, GetCandlesOpts, GetHistoricalFundingOpts, GetTradesOpts, IndexerClient,
     ListPerpetualMarketsOpts, SparklineTimePeriod, Ticker,
 };

--- a/v4-client-rs/client/examples/noble_transfer.rs
+++ b/v4-client-rs/client/examples/noble_transfer.rs
@@ -4,10 +4,10 @@ use anyhow::Result;
 mod noble_transfer_example {
     use super::*;
     use anyhow::{anyhow as err, Error};
-    use dydx_v4_rust::config::ClientConfig;
-    use dydx_v4_rust::indexer::Token;
-    use dydx_v4_rust::noble::{NobleClient, NobleUsdc};
-    use dydx_v4_rust::node::{NodeClient, Wallet};
+    use dydx::config::ClientConfig;
+    use dydx::indexer::Token;
+    use dydx::noble::{NobleClient, NobleUsdc};
+    use dydx::node::{NodeClient, Wallet};
     use tokio::time::{sleep, Duration};
 
     const TEST_MNEMONIC: &str = "mirror actor skill push coach wait confirm orchard lunch mobile athlete gossip awake miracle matter bus reopen team ladder lazy list timber render wait";

--- a/v4-client-rs/client/examples/place_order_long_term.rs
+++ b/v4-client-rs/client/examples/place_order_long_term.rs
@@ -2,11 +2,11 @@ mod support;
 use anyhow::{Error, Result};
 use bigdecimal::BigDecimal;
 use chrono::{TimeDelta, Utc};
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::indexer::{ClientId, IndexerClient, Ticker};
-use dydx_v4_rust::node::{NodeClient, OrderBuilder, OrderSide, Wallet};
+use dydx::config::ClientConfig;
+use dydx::indexer::{ClientId, IndexerClient, Ticker};
+use dydx::node::{NodeClient, OrderBuilder, OrderSide, Wallet};
+use dydx_proto::dydxprotocol::clob::order::TimeInForce;
 use support::constants::TEST_MNEMONIC;
-use v4_proto_rs::dydxprotocol::clob::order::TimeInForce;
 
 const ETH_USD_TICKER: &str = "ETH-USD";
 

--- a/v4-client-rs/client/examples/place_order_short_term.rs
+++ b/v4-client-rs/client/examples/place_order_short_term.rs
@@ -1,12 +1,12 @@
 mod support;
 use anyhow::{Error, Result};
 use bigdecimal::BigDecimal;
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::indexer::IndexerClient;
-use dydx_v4_rust::node::{NodeClient, OrderBuilder, OrderSide, Wallet};
+use dydx::config::ClientConfig;
+use dydx::indexer::IndexerClient;
+use dydx::node::{NodeClient, OrderBuilder, OrderSide, Wallet};
+use dydx_proto::dydxprotocol::clob::order::TimeInForce;
 use std::str::FromStr;
 use support::constants::TEST_MNEMONIC;
-use v4_proto_rs::dydxprotocol::clob::order::TimeInForce;
 
 const ETH_USD_TICKER: &str = "ETH-USD";
 

--- a/v4-client-rs/client/examples/send_token.rs
+++ b/v4-client-rs/client/examples/send_token.rs
@@ -1,8 +1,8 @@
 mod support;
 use anyhow::{Error, Result};
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::indexer::Token;
-use dydx_v4_rust::node::{NodeClient, Wallet};
+use dydx::config::ClientConfig;
+use dydx::indexer::Token;
+use dydx::node::{NodeClient, Wallet};
 use support::constants::TEST_MNEMONIC;
 
 pub struct Transferor {

--- a/v4-client-rs/client/examples/sequencer.rs
+++ b/v4-client-rs/client/examples/sequencer.rs
@@ -3,16 +3,14 @@ use anyhow::{Error, Result};
 use async_trait::async_trait;
 use bigdecimal::BigDecimal;
 use chrono::{TimeDelta, Utc};
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::indexer::{
-    Address, ClientId, IndexerClient, PerpetualMarket, Subaccount, Ticker,
-};
-use dydx_v4_rust::node::{sequencer::*, Account, NodeClient, OrderBuilder, OrderSide, Wallet};
+use dydx::config::ClientConfig;
+use dydx::indexer::{Address, ClientId, IndexerClient, PerpetualMarket, Subaccount, Ticker};
+use dydx::node::{sequencer::*, Account, NodeClient, OrderBuilder, OrderSide, Wallet};
+use dydx_proto::dydxprotocol::clob::order::TimeInForce;
 use std::sync::Arc;
 use support::constants::TEST_MNEMONIC;
 use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration};
-use v4_proto_rs::dydxprotocol::clob::order::TimeInForce;
 
 const ETH_USD_TICKER: &str = "ETH-USD";
 

--- a/v4-client-rs/client/examples/support/order_book.rs
+++ b/v4-client-rs/client/examples/support/order_book.rs
@@ -1,6 +1,6 @@
 use bigdecimal::Zero;
 use derive_more::{Deref, DerefMut};
-use dydx_v4_rust::indexer::{
+use dydx::indexer::{
     Feed, OrderBookResponseObject, OrderbookResponsePriceLevel, OrdersMessage, Price, Quantity,
 };
 use std::collections::BTreeMap;

--- a/v4-client-rs/client/examples/transfer.rs
+++ b/v4-client-rs/client/examples/transfer.rs
@@ -1,7 +1,7 @@
 mod support;
 use anyhow::{Error, Result};
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::node::{NodeClient, Wallet};
+use dydx::config::ClientConfig;
+use dydx::node::{NodeClient, Wallet};
 use support::constants::TEST_MNEMONIC;
 
 pub struct Transferor {

--- a/v4-client-rs/client/examples/utility_endpoint.rs
+++ b/v4-client-rs/client/examples/utility_endpoint.rs
@@ -1,8 +1,8 @@
 mod support;
 use anyhow::{Error, Result};
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::indexer::IndexerClient;
-use dydx_v4_rust::node::Wallet;
+use dydx::config::ClientConfig;
+use dydx::indexer::IndexerClient;
+use dydx::node::Wallet;
 use support::constants::TEST_MNEMONIC;
 
 pub struct Rester {

--- a/v4-client-rs/client/examples/validator_get.rs
+++ b/v4-client-rs/client/examples/validator_get.rs
@@ -1,7 +1,7 @@
 mod support;
 use anyhow::{Error, Result};
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::node::{NodeClient, Wallet};
+use dydx::config::ClientConfig;
+use dydx::node::{NodeClient, Wallet};
 use support::constants::TEST_MNEMONIC;
 
 const ETH_USD_PAIR_ID: u32 = 1;

--- a/v4-client-rs/client/examples/validator_post.rs
+++ b/v4-client-rs/client/examples/validator_post.rs
@@ -1,15 +1,15 @@
 mod support;
 use anyhow::{Error, Result};
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::node::{NodeClient, Wallet};
-use rand::{thread_rng, Rng};
-use support::constants::TEST_MNEMONIC;
-use tokio::time::{sleep, Duration};
-use v4_proto_rs::dydxprotocol::clob::{
+use dydx::config::ClientConfig;
+use dydx::node::{NodeClient, Wallet};
+use dydx_proto::dydxprotocol::clob::{
     order::{ConditionType, GoodTilOneof, Side, TimeInForce},
     Order, OrderId,
 };
-use v4_proto_rs::dydxprotocol::subaccounts::SubaccountId;
+use dydx_proto::dydxprotocol::subaccounts::SubaccountId;
+use rand::{thread_rng, Rng};
+use support::constants::TEST_MNEMONIC;
+use tokio::time::{sleep, Duration};
 
 const ETH_USD_PAIR_ID: u32 = 1;
 const ETH_USD_QUANTUMS: u64 = 10_000_000; // calculated based on market

--- a/v4-client-rs/client/examples/wallet.rs
+++ b/v4-client-rs/client/examples/wallet.rs
@@ -1,9 +1,9 @@
 mod support;
 use anyhow::{Error, Result};
-use dydx_v4_rust::config::ClientConfig;
+use dydx::config::ClientConfig;
 #[cfg(feature = "noble")]
-use dydx_v4_rust::noble::NobleClient;
-use dydx_v4_rust::node::{NodeClient, Wallet};
+use dydx::noble::NobleClient;
+use dydx::node::{NodeClient, Wallet};
 use support::constants::TEST_MNEMONIC;
 
 #[tokio::main]

--- a/v4-client-rs/client/examples/websockets.rs
+++ b/v4-client-rs/client/examples/websockets.rs
@@ -1,11 +1,11 @@
 mod support;
 use anyhow::{Error, Result};
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::indexer::{
+use dydx::config::ClientConfig;
+use dydx::indexer::{
     BlockHeightMessage, CandleResolution, CandlesMessage, Feed, IndexerClient, MarketsMessage,
     OrdersMessage, ParentSubaccountsMessage, SubaccountsMessage, Ticker, TradesMessage,
 };
-use dydx_v4_rust::node::Wallet;
+use dydx::node::Wallet;
 use support::constants::TEST_MNEMONIC;
 use tokio::select;
 

--- a/v4-client-rs/client/examples/withdraw.rs
+++ b/v4-client-rs/client/examples/withdraw.rs
@@ -1,7 +1,7 @@
 mod support;
 use anyhow::{Error, Result};
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::node::{NodeClient, Wallet};
+use dydx::config::ClientConfig;
+use dydx::node::{NodeClient, Wallet};
 use support::constants::TEST_MNEMONIC;
 
 pub struct Transferor {

--- a/v4-client-rs/client/examples/withdraw_other.rs
+++ b/v4-client-rs/client/examples/withdraw_other.rs
@@ -1,13 +1,13 @@
 mod support;
 use anyhow::{Error, Result};
-use dydx_v4_rust::config::ClientConfig;
-use dydx_v4_rust::node::{NodeClient, Wallet};
-use std::iter::once;
-use support::constants::TEST_MNEMONIC;
-use v4_proto_rs::{
+use dydx::config::ClientConfig;
+use dydx::node::{NodeClient, Wallet};
+use dydx_proto::{
     dydxprotocol::{sending::MsgWithdrawFromSubaccount, subaccounts::SubaccountId},
     ToAny,
 };
+use std::iter::once;
+use support::constants::TEST_MNEMONIC;
 
 pub struct Transferor {
     client: NodeClient,

--- a/v4-client-rs/client/src/indexer/tokens.rs
+++ b/v4-client-rs/client/src/indexer/tokens.rs
@@ -2,7 +2,7 @@ use crate::indexer::Denom;
 use anyhow::{anyhow as err, Error};
 use bigdecimal::{num_traits::ToPrimitive, BigDecimal, One};
 use derive_more::{Deref, DerefMut, From};
-use v4_proto_rs::cosmos_sdk_proto::cosmos::base::v1beta1::Coin as ProtoCoin;
+use dydx_proto::cosmos_sdk_proto::cosmos::base::v1beta1::Coin as ProtoCoin;
 
 /// USDC token.
 #[derive(Debug, Deref, DerefMut, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/v4-client-rs/client/src/indexer/types.rs
+++ b/v4-client-rs/client/src/indexer/types.rs
@@ -4,13 +4,13 @@ use bigdecimal::BigDecimal;
 use chrono::{DateTime, Utc};
 use cosmrs::{AccountId, Denom as CosmosDenom};
 use derive_more::{Add, Deref, DerefMut, Display, Div, From, Mul, Sub};
+use dydx_proto::dydxprotocol::subaccounts::SubaccountId as ProtoSubaccountId;
 use rand::{thread_rng, Rng};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::{fmt, str::FromStr};
-use v4_proto_rs::dydxprotocol::subaccounts::SubaccountId as ProtoSubaccountId;
 
 // Shared types used by REST API, WS
 
@@ -124,7 +124,7 @@ pub struct AnyId;
 /// Client ID defined by the user to identify orders.
 ///
 /// This value should be different for different orders.
-/// To update a specific previously submitted order, the new [`Order`](v4_proto_rs::dydxprotocol::clob::Order) must have the same client ID, and the same [`OrderId`].
+/// To update a specific previously submitted order, the new [`Order`](dydx_proto::dydxprotocol::clob::Order) must have the same client ID, and the same [`OrderId`].
 /// See also: [How can I replace an order?](https://docs.dydx.exchange/introduction-onboarding_faqs).
 #[serde_as]
 #[derive(Deserialize, Debug, Clone, Display, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/v4-client-rs/client/src/noble/mod.rs
+++ b/v4-client-rs/client/src/noble/mod.rs
@@ -8,14 +8,7 @@ use anyhow::{anyhow as err, Error};
 use chrono::{TimeDelta, Utc};
 pub use config::NobleConfig;
 use cosmrs::tx::{self, Tx};
-use ibc_proto::{
-    cosmos::base::v1beta1::Coin as IbcProtoCoin, ibc::applications::transfer::v1::MsgTransfer,
-};
-pub use tokens::NobleUsdc;
-use tokio::time::Duration;
-use tonic::transport::{Channel, ClientTlsConfig};
-use tower::timeout::Timeout;
-use v4_proto_rs::{
+use dydx_proto::{
     cosmos_sdk_proto::cosmos::{
         auth::v1beta1::{
             query_client::QueryClient as AuthClient, BaseAccount, QueryAccountRequest,
@@ -31,6 +24,13 @@ use v4_proto_rs::{
     },
     ToAny,
 };
+use ibc_proto::{
+    cosmos::base::v1beta1::Coin as IbcProtoCoin, ibc::applications::transfer::v1::MsgTransfer,
+};
+pub use tokens::NobleUsdc;
+use tokio::time::Duration;
+use tonic::transport::{Channel, ClientTlsConfig};
+use tower::timeout::Timeout;
 
 /// Wrapper over standard [Cosmos modules](https://github.com/cosmos/cosmos-sdk/tree/main/x) clients.
 pub struct Routes {

--- a/v4-client-rs/client/src/noble/tokens.rs
+++ b/v4-client-rs/client/src/noble/tokens.rs
@@ -1,7 +1,7 @@
 use crate::indexer::{Denom, Tokenized};
 use anyhow::{anyhow as err, Error};
 use bigdecimal::{num_traits::ToPrimitive, BigDecimal};
-use v4_proto_rs::cosmos_sdk_proto::cosmos::base::v1beta1::Coin as ProtoCoin;
+use dydx_proto::cosmos_sdk_proto::cosmos::base::v1beta1::Coin as ProtoCoin;
 
 /// USDC Noble token.
 pub struct NobleUsdc(pub BigDecimal);

--- a/v4-client-rs/client/src/node/client/methods.rs
+++ b/v4-client-rs/client/src/node/client/methods.rs
@@ -1,7 +1,7 @@
 use super::{Address, NodeClient};
 use crate::indexer::{Denom, Height, Subaccount};
 use anyhow::{anyhow as err, Error};
-use v4_proto_rs::{
+use dydx_proto::{
     cosmos::base::query::v1beta1::PageRequest as V4PageRequest,
     cosmos_sdk_proto::cosmos::{
         auth::v1beta1::{BaseAccount, QueryAccountRequest},

--- a/v4-client-rs/client/src/node/client/mod.rs
+++ b/v4-client-rs/client/src/node/client/mod.rs
@@ -15,20 +15,7 @@ use bigdecimal::{
 use chrono::{TimeDelta, Utc};
 use cosmrs::tx::{self, Tx};
 use derive_more::{Deref, DerefMut};
-pub use error::*;
-#[cfg(feature = "noble")]
-use ibc_proto::{
-    cosmos::base::v1beta1::Coin as IbcProtoCoin,
-    ibc::applications::transfer::v1::MsgTransfer as IbcMsgTransfer,
-};
-use std::iter;
-use tokio::time::{sleep, Duration};
-use tonic::{
-    transport::{Channel, ClientTlsConfig},
-    Code,
-};
-use tower::timeout::Timeout;
-use v4_proto_rs::{
+use dydx_proto::{
     cosmos_sdk_proto::cosmos::{
         auth::v1beta1::query_client::QueryClient as AuthClient,
         bank::v1beta1::{query_client::QueryClient as BankClient, MsgSend},
@@ -58,6 +45,19 @@ use v4_proto_rs::{
     },
     ToAny,
 };
+pub use error::*;
+#[cfg(feature = "noble")]
+use ibc_proto::{
+    cosmos::base::v1beta1::Coin as IbcProtoCoin,
+    ibc::applications::transfer::v1::MsgTransfer as IbcMsgTransfer,
+};
+use std::iter;
+use tokio::time::{sleep, Duration};
+use tonic::{
+    transport::{Channel, ClientTlsConfig},
+    Code,
+};
+use tower::timeout::Timeout;
 
 #[cfg(feature = "telemetry")]
 use crate::telemetry::{

--- a/v4-client-rs/client/src/node/order.rs
+++ b/v4-client-rs/client/src/node/order.rs
@@ -6,11 +6,11 @@ use anyhow::{anyhow as err, Error};
 use bigdecimal::{num_traits::cast::ToPrimitive, BigDecimal, One};
 use chrono::{DateTime, Utc};
 use derive_more::From;
-pub use v4_proto_rs::dydxprotocol::clob::{
+pub use dydx_proto::dydxprotocol::clob::{
     order::{Side as OrderSide, TimeInForce as OrderTimeInForce},
     OrderId,
 };
-use v4_proto_rs::dydxprotocol::{
+use dydx_proto::dydxprotocol::{
     clob::{
         msg_cancel_order,
         order::{self, ConditionType},

--- a/v4-client-rs/client/src/node/sequencer.rs
+++ b/v4-client-rs/client/src/node/sequencer.rs
@@ -4,15 +4,15 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 
 use super::Address;
-use std::collections::HashMap;
-use tonic::{transport::Channel, Request};
-use tower::timeout::Timeout;
-use v4_proto_rs::cosmos_sdk_proto::{
+use dydx_proto::cosmos_sdk_proto::{
     cosmos::auth::v1beta1::{
         query_client::QueryClient as QueryGrpcClient, BaseAccount, QueryAccountRequest,
     },
     traits::Message,
 };
+use std::collections::HashMap;
+use tonic::{transport::Channel, Request};
+use tower::timeout::Timeout;
 
 /// Transaction sequence number validation value used to enable protection against replay attacks.
 #[derive(Clone, Debug)]

--- a/v4-client-rs/client/tests/env.rs
+++ b/v4-client-rs/client/tests/env.rs
@@ -1,10 +1,10 @@
 use anyhow::{anyhow as err, Error, Result};
 use chrono::{TimeDelta, Utc};
 #[cfg(feature = "faucet")]
-use dydx_v4_rust::faucet::FaucetClient;
+use dydx::faucet::FaucetClient;
 #[cfg(feature = "noble")]
-use dydx_v4_rust::noble::NobleClient;
-use dydx_v4_rust::{
+use dydx::noble::NobleClient;
+use dydx::{
     config::ClientConfig,
     indexer::{ClientId, Height, IndexerClient, PerpetualMarket, Ticker},
     node::{Account, Address, NodeClient, OrderBuilder, OrderId, OrderSide, Subaccount, Wallet},

--- a/v4-client-rs/client/tests/test_faucet.rs
+++ b/v4-client-rs/client/tests/test_faucet.rs
@@ -6,7 +6,7 @@ mod faucet_tests {
     use env::TestEnv;
 
     use anyhow::Error;
-    use dydx_v4_rust::indexer::Usdc;
+    use dydx::indexer::Usdc;
 
     const FILL_AMOUNT: u64 = 1_000_000;
 

--- a/v4-client-rs/client/tests/test_indexer_rest.rs
+++ b/v4-client-rs/client/tests/test_indexer_rest.rs
@@ -3,7 +3,7 @@ use env::TestEnv;
 
 use anyhow::{anyhow as err, Result};
 use bigdecimal::BigDecimal;
-use dydx_v4_rust::indexer::*;
+use dydx::indexer::*;
 use std::str::FromStr;
 
 #[tokio::test]

--- a/v4-client-rs/client/tests/test_indexer_sock.rs
+++ b/v4-client-rs/client/tests/test_indexer_sock.rs
@@ -2,7 +2,7 @@ mod env;
 use env::TestEnv;
 
 use anyhow::{anyhow as err, Error};
-use dydx_v4_rust::indexer::*;
+use dydx::indexer::*;
 use tokio::time::{sleep, Duration, Instant};
 
 #[tokio::test]

--- a/v4-client-rs/client/tests/test_noble.rs
+++ b/v4-client-rs/client/tests/test_noble.rs
@@ -6,8 +6,8 @@ mod noble_tests {
     use env::TestEnv;
 
     use anyhow::Error;
-    use dydx_v4_rust::indexer::Denom;
-    use dydx_v4_rust::noble::NobleUsdc;
+    use dydx::indexer::Denom;
+    use dydx::noble::NobleUsdc;
     use serial_test::serial;
 
     #[tokio::test]

--- a/v4-client-rs/client/tests/test_node.rs
+++ b/v4-client-rs/client/tests/test_node.rs
@@ -4,21 +4,21 @@ use env::TestEnv;
 use anyhow::{anyhow as err, Error};
 use bigdecimal::{num_traits::cast::ToPrimitive, BigDecimal, One};
 use chrono::{TimeDelta, Utc};
-use dydx_v4_rust::{
+use dydx::{
     indexer::{OrderExecution, Token},
     node::*,
 };
-use rand::{thread_rng, Rng};
-use serial_test::serial;
-use std::str::FromStr;
-use tokio::time::{sleep, Duration};
-use v4_proto_rs::dydxprotocol::{
+use dydx_proto::dydxprotocol::{
     clob::{
         order::{self, ConditionType, Side, TimeInForce},
         Order, OrderBatch, OrderId,
     },
     subaccounts::SubaccountId,
 };
+use rand::{thread_rng, Rng};
+use serial_test::serial;
+use std::str::FromStr;
+use tokio::time::{sleep, Duration};
 
 const ETH_USD_PAIR_ID: u32 = 1; // information on market id can be fetch from indexer API
 

--- a/v4-client-rs/client/tests/test_node_methods.rs
+++ b/v4-client-rs/client/tests/test_node_methods.rs
@@ -2,7 +2,7 @@ mod env;
 use env::TestEnv;
 
 use anyhow::Result;
-use dydx_v4_rust::indexer::Denom;
+use dydx::indexer::Denom;
 
 #[tokio::test]
 async fn test_node_get_account_balances() -> Result<()> {

--- a/v4-client-rs/client/tests/test_node_sequencer.rs
+++ b/v4-client-rs/client/tests/test_node_sequencer.rs
@@ -2,7 +2,7 @@ mod env;
 use env::TestEnv;
 
 use anyhow::Error;
-use dydx_v4_rust::node::sequencer::*;
+use dydx::node::sequencer::*;
 use serial_test::serial;
 
 #[tokio::test]

--- a/v4-client-rs/deny.toml
+++ b/v4-client-rs/deny.toml
@@ -25,16 +25,16 @@ allow = [
     "ISC",
     "Unicode-DFS-2016",
     "OpenSSL",
+    "LicenseRef-dYdX-Custom",
 ]
 confidence-threshold = 0.8
-[[licenses.exceptions]]
-allow = ["AGPL-3.0"]
-name = "v4-proto-rs"
-version = "*"
-[[licenses.exceptions]]
-allow = ["AGPL-3.0"]
-name = "dydx-v4-rust"
-version = "*"
+
+[[licenses.clarify]]
+crate = "dydx-proto"
+expression = "LicenseRef-dYdX-Custom"
+license-files = [
+    { path = "LICENSE", hash = 0x30bcd1e3 },
+]
 
 [[licenses.clarify]]
 name = "ring"
@@ -56,7 +56,6 @@ highlight = "all"
 unknown-registry = "warn"
 unknown-git = "warn"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = ["https://github.com/therustmonk/v4-chain.git"]
 
 [sources.allow-org]
 github = []


### PR DESCRIPTION
Changes,
- Rust client crate name to `dydx`;
- Use protobufs dep `dydx-proto` from registry;
- Changes license reference to `LicenseRef-dYdX-Custom`.