### PR TITLE
chore: Fix Rust client Cargo.toml repository link

### DIFF
--- a/v4-client-rs/client/Cargo.toml
+++ b/v4-client-rs/client/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 readme.workspace = true
 description = "dYdX v4 asynchronous client."
-repository = "https://github.com/dydxprotocol/v4-clients/v4-client-rs"
+repository = "https://github.com/dydxprotocol/v4-clients/tree/main/v4-client-rs"
 
 # https://crates.io/categories
 categories = ["api-bindings", "asynchronous", "finance"]


### PR DESCRIPTION
Fixes GitHub link pointing to the package source. Affects the link shown in the crates.io page. 