### PR TITLE
feat: Add Vaults REST API

### DIFF
--- a/v4-client-rs/client/examples/support/constants.rs
+++ b/v4-client-rs/client/examples/support/constants.rs
@@ -1,1 +1,2 @@
+#[allow(dead_code)]
 pub const TEST_MNEMONIC: &str = "mirror actor skill push coach wait confirm orchard lunch mobile athlete gossip awake miracle matter bus reopen team ladder lazy list timber render wait";

--- a/v4-client-rs/client/examples/vault_endpoint.rs
+++ b/v4-client-rs/client/examples/vault_endpoint.rs
@@ -1,0 +1,43 @@
+mod support;
+use anyhow::{Error, Result};
+use dydx::config::ClientConfig;
+use dydx::indexer::{IndexerClient, PnlTickInterval};
+
+pub struct Rester {
+    indexer: IndexerClient,
+}
+
+impl Rester {
+    pub async fn connect() -> Result<Self> {
+        let config = ClientConfig::from_file("client/tests/testnet.toml").await?;
+        let indexer = IndexerClient::new(config.indexer);
+        Ok(Self { indexer })
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt().try_init().map_err(Error::msg)?;
+    let rester = Rester::connect().await?;
+    let indexer = rester.indexer;
+
+    // Test values
+    let resolution = PnlTickInterval::Hour;
+
+    let pnls = indexer
+        .vaults()
+        .get_megavault_historical_pnl(resolution)
+        .await?;
+    tracing::info!("MegaVault historical PnLs: {pnls:?}");
+
+    let vaults_pnls = indexer
+        .vaults()
+        .get_vaults_historical_pnl(resolution)
+        .await?;
+    tracing::info!("Vaults historical PnLs: {vaults_pnls:?}");
+
+    let positions = indexer.vaults().get_megavault_positions().await?;
+    tracing::info!("MegaVault positions: {positions:?}");
+
+    Ok(())
+}

--- a/v4-client-rs/client/src/indexer/mod.rs
+++ b/v4-client-rs/client/src/indexer/mod.rs
@@ -44,6 +44,11 @@ impl IndexerClient {
         self.rest.utility()
     }
 
+    /// Get vaults query dispatcher.
+    pub fn vaults(&self) -> rest::Vaults {
+        self.rest.vaults()
+    }
+
     /// Get feeds dispatcher.
     pub fn feed(&mut self) -> Feeds<'_> {
         Feeds::new(&mut self.sock)

--- a/v4-client-rs/client/src/indexer/rest/client/mod.rs
+++ b/v4-client-rs/client/src/indexer/rest/client/mod.rs
@@ -1,6 +1,7 @@
 pub mod accounts;
 pub mod markets;
 pub mod utility;
+pub mod vaults;
 
 use super::config::RestConfig;
 use super::options::*;
@@ -10,6 +11,7 @@ use markets::Markets;
 use reqwest::Client;
 use serde::Serialize;
 use utility::Utility;
+use vaults::Vaults;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -54,5 +56,10 @@ impl RestClient {
     /// Get utility query dispatcher.
     pub(crate) fn utility(&self) -> Utility<'_> {
         Utility::new(self)
+    }
+
+    /// Get vaults query dispatcher.
+    pub(crate) fn vaults(&self) -> Vaults<'_> {
+        Vaults::new(self)
     }
 }

--- a/v4-client-rs/client/src/indexer/rest/client/vaults.rs
+++ b/v4-client-rs/client/src/indexer/rest/client/vaults.rs
@@ -1,0 +1,75 @@
+use super::*;
+use anyhow::Error;
+
+/// Vaults dispatcher.
+///
+/// Check [the example](https://github.com/NethermindEth/dydx-v4-rust/blob/trunk/client/examples/vaults_endpoint.rs).
+pub struct Vaults<'a> {
+    rest: &'a RestClient,
+}
+
+impl<'a> Vaults<'a> {
+    /// Create a new vaults dispatcher.
+    pub(crate) fn new(rest: &'a RestClient) -> Self {
+        Self { rest }
+    }
+
+    /// MegaVault historical PnL.
+    pub async fn get_megavault_historical_pnl(
+        &self,
+        resolution: PnlTickInterval,
+    ) -> Result<Vec<PnlTicksResponseObject>, Error> {
+        let rest = &self.rest;
+        const URI: &str = "/v4/vault/v1/megavault/historicalPnl";
+        let url = format!("{}{URI}", rest.config.endpoint);
+        let resp = rest
+            .client
+            .get(url)
+            .query(&[("resolution", resolution)])
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<MegaVaultHistoricalPnlResponse>()
+            .await?
+            .megavault_pnl;
+        Ok(resp)
+    }
+
+    /// Vaults historical PnL.
+    pub async fn get_vaults_historical_pnl(
+        &self,
+        resolution: PnlTickInterval,
+    ) -> Result<Vec<VaultHistoricalPnl>, Error> {
+        let rest = &self.rest;
+        const URI: &str = "/v4/vault/v1/vaults/historicalPnl";
+        let url = format!("{}{URI}", rest.config.endpoint);
+        let resp = rest
+            .client
+            .get(url)
+            .query(&[("resolution", resolution)])
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<VaultsHistoricalPnLResponse>()
+            .await?
+            .vaults_pnl;
+        Ok(resp)
+    }
+
+    /// MegaVault positions.
+    pub async fn get_megavault_positions(&self) -> Result<Vec<VaultPosition>, Error> {
+        let rest = &self.rest;
+        const URI: &str = "/v4/vault/v1/megavault/positions";
+        let url = format!("{}{URI}", rest.config.endpoint);
+        let resp = rest
+            .client
+            .get(url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<MegaVaultPositionResponse>()
+            .await?
+            .positions;
+        Ok(resp)
+    }
+}

--- a/v4-client-rs/client/src/indexer/rest/mod.rs
+++ b/v4-client-rs/client/src/indexer/rest/mod.rs
@@ -11,3 +11,4 @@ pub use types::*;
 pub use client::accounts::Accounts;
 pub use client::markets::Markets;
 pub use client::utility::Utility;
+pub use client::vaults::Vaults;

--- a/v4-client-rs/client/src/indexer/rest/types.rs
+++ b/v4-client-rs/client/src/indexer/rest/types.rs
@@ -30,6 +30,18 @@ pub struct ErrorMsg {
 #[derive(Deserialize, Debug, Clone, From, Display, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PnlTickId(pub String);
 
+/// PnL tick resolution.
+#[derive(
+    Deserialize, Serialize, Debug, Clone, Copy, From, Display, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum PnlTickInterval {
+    /// Hour.
+    Hour,
+    /// Day.
+    Day,
+}
+
 /// Transfer id.
 #[derive(
     Serialize, Deserialize, Debug, Clone, From, Display, PartialEq, Eq, PartialOrd, Ord, Hash,
@@ -300,4 +312,52 @@ pub struct HistoricalTradingRewardAggregation {
     pub ended_at: Option<DateTime<Utc>>,
     /// Aggregation period.
     pub period: TradingRewardAggregationPeriod,
+}
+
+/// MegaVault Profit and loss reports.
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct MegaVaultHistoricalPnlResponse {
+    /// List of PnL reports.
+    pub megavault_pnl: Vec<PnlTicksResponseObject>,
+}
+
+/// MegaVault Profit and loss reports.
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct MegaVaultPositionResponse {
+    /// List MegaVault positions.
+    pub positions: Vec<VaultPosition>,
+}
+
+/// Vaults profit and loss reports.
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultsHistoricalPnLResponse {
+    /// List of PnL reports.
+    pub vaults_pnl: Vec<VaultHistoricalPnl>,
+}
+
+/// Vault Profit and loss reports.
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultHistoricalPnl {
+    /// Associated ticker.
+    pub ticker: String,
+    /// List of PnL reports.
+    pub historical_pnl: Vec<PnlTicksResponseObject>,
+}
+
+/// Vault position.
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct VaultPosition {
+    /// Associated ticker.
+    pub ticker: String,
+    /// Asset position.
+    pub asset_position: Option<AssetPositionResponseObject>,
+    /// Perpetual position.
+    pub perpetual_position: Option<PerpetualPositionResponseObject>,
+    /// Equity.
+    pub equity: BigDecimal,
 }

--- a/v4-client-rs/client/tests/test_indexer_rest.rs
+++ b/v4-client-rs/client/tests/test_indexer_rest.rs
@@ -283,6 +283,35 @@ async fn test_indexer_account_get_rewards_aggregated() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_indexer_vaults_get_megavault_historical_pnl() -> Result<()> {
+    let env = TestEnv::testnet().await?;
+    let resolution = PnlTickInterval::Hour;
+    env.indexer
+        .vaults()
+        .get_megavault_historical_pnl(resolution)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_indexer_vaults_get_vaults_historical_pnl() -> Result<()> {
+    let env = TestEnv::testnet().await?;
+    let resolution = PnlTickInterval::Hour;
+    env.indexer
+        .vaults()
+        .get_vaults_historical_pnl(resolution)
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_indexer_vaults_get_megavault_positions() -> Result<()> {
+    let env = TestEnv::testnet().await?;
+    env.indexer.vaults().get_megavault_positions().await?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_perpetual_market_quantization() -> Result<()> {
     let env = TestEnv::testnet().await?;
     let markets = env.indexer.markets().list_perpetual_markets(None).await?;


### PR DESCRIPTION
Adds Vaults REST API (3 methods). An example is also provided. The provided tests test if the Indexer responses are correctly parsed.