### PR TITLE
chore: Allow the `Unicode-3.0` license

### DIFF
--- a/v4-client-rs/deny.toml
+++ b/v4-client-rs/deny.toml
@@ -24,6 +24,7 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "Unicode-DFS-2016",
+    "Unicode-3.0",
     "OpenSSL",
     "LicenseRef-dYdX-Custom",
 ]


### PR DESCRIPTION
Allow `Unicode-3.0` since it is permissive. Employed by the dependency [`icu4x`](https://github.com/unicode-org/icu4x), an indirect dependency of `reqwest`.