### PR TITLE
docs: Add CHANGELOG

### DIFF
--- a/v4-client-rs/CHANGELOG.md
+++ b/v4-client-rs/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.1] - 2024-12-02
+
+### 🚀 Features
+
+- Add Vaults REST API (#291)
+- Add Validator/`NodeClient` MegaVault methods (#300)
+
+### ⚙️ Miscellaneous Tasks
+
+- Fix Rust client Cargo.toml README path (#281)
+- Fix Rust client Cargo.toml repository link (#284)
+- Allow the `Unicode-3.0` license (#292)
+- Update dependencies (#295)
+
+## [0.1.0] - 2024-10-28
+
+### 🚀 Features
+
+- Rust client implementation (#268)

--- a/v4-client-rs/Cargo.toml
+++ b/v4-client-rs/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "LicenseRef-dYdX-Custom"
 


### PR DESCRIPTION
Slightly modified output of `git cliff`:
```sh
git cliff --include-path "v4-client-rs/**/*" --repository "../" -o
```

Also bumps crate version to `0.1.1`.