### PR TITLE
feat(config): Implement Serialize trait for configuration structs

### DIFF
--- a/v4-client-rs/client/src/config.rs
+++ b/v4-client-rs/client/src/config.rs
@@ -4,12 +4,12 @@ use super::faucet::FaucetConfig;
 use super::noble::NobleConfig;
 use super::{indexer::IndexerConfig, node::NodeConfig};
 use anyhow::Error;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 use tokio::fs;
 
 /// Serves as a configuration wrapper over configurations for specific clients.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ClientConfig {
     /// Configuration for [`IndexerClient`](crate::indexer::IndexerClient)
     pub indexer: IndexerConfig,

--- a/v4-client-rs/client/src/faucet.rs
+++ b/v4-client-rs/client/src/faucet.rs
@@ -5,7 +5,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
 /// Configuration for the Faucet client.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct FaucetConfig {
     /// The base url of the faucet service.
     pub endpoint: String,

--- a/v4-client-rs/client/src/indexer/config.rs
+++ b/v4-client-rs/client/src/indexer/config.rs
@@ -1,8 +1,8 @@
 pub use crate::indexer::{rest::RestConfig, sock::SockConfig};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Indexer client configuration.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct IndexerConfig {
     /// Indexer REST client configuration.
     #[serde(alias = "http")]

--- a/v4-client-rs/client/src/indexer/rest/config.rs
+++ b/v4-client-rs/client/src/indexer/rest/config.rs
@@ -1,7 +1,7 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// REST Indexer client configuration.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RestConfig {
     /// REST endpoint.
     ///

--- a/v4-client-rs/client/src/indexer/sock/config.rs
+++ b/v4-client-rs/client/src/indexer/sock/config.rs
@@ -1,8 +1,8 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::num::NonZeroU32;
 
 /// Websocket Indexer client configuration.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SockConfig {
     /// Websocket endpoint.
     ///

--- a/v4-client-rs/client/src/noble/config.rs
+++ b/v4-client-rs/client/src/noble/config.rs
@@ -1,9 +1,9 @@
 use crate::indexer::Denom;
 use cosmrs::tendermint::chain::Id as ChainId;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Configuration for [`NobleClient`](crate::noble::NobleClient)
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct NobleConfig {
     /// Node endpoint.
     pub endpoint: String,

--- a/v4-client-rs/client/src/node/config.rs
+++ b/v4-client-rs/client/src/node/config.rs
@@ -1,9 +1,9 @@
 use crate::indexer::Denom;
 use crate::node::ChainId;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Configuration for [`NodeClient`](crate::node::NodeClient)
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct NodeConfig {
     /// Node endpoint.
     ///

--- a/v4-client-rs/client/src/node/types.rs
+++ b/v4-client-rs/client/src/node/types.rs
@@ -1,12 +1,12 @@
 use cosmrs::tendermint::{chain::Id, error::Error};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, Display};
 
 /// [Chain ID](https://docs.dydx.exchange/infrastructure_providers-network/network_constants#chain-id)
 /// serves as a unique chain identificator to prevent replay attacks.
 ///
 /// See also [Cosmos ecosystem](https://cosmos.directory/).
-#[derive(Debug, Eq, PartialEq, Clone, Display, AsRefStr, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Clone, Display, AsRefStr, Deserialize, Serialize)]
 pub enum ChainId {
     /// Testnet.
     #[strum(serialize = "dydx-testnet-4")]


### PR DESCRIPTION
This commit adds support for serializing configuration structures by implementing the `Serialize` trait for them.

This change is necessary for enabling configuration data to be converted into formats like JSON or TOML, which facilitates easier storage, transmission, or debugging. By leveraging the `Serialize` trait, developers can integrate the configuration with existing systems that require serialized data formats.