### PR TITLE
feat: Permissioned keys

### DIFF
--- a/v4-client-rs/client/Cargo.toml
+++ b/v4-client-rs/client/Cargo.toml
@@ -28,6 +28,7 @@ bigdecimal.workspace = true
 bip32 = { version = "0.5", default-features = false, features = ["bip39", "alloc", "secp256k1"] }
 cosmrs = "0.21"
 chrono = { version = "0.4", features = ["serde"] }
+delegate = "0.13"
 derive_more.workspace = true
 futures-util = "0.3"
 governor = { version = "0.8", default-features = false, features = ["std"] }

--- a/v4-client-rs/client/Cargo.toml
+++ b/v4-client-rs/client/Cargo.toml
@@ -26,7 +26,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 bigdecimal.workspace = true
 bip32 = { version = "0.5", default-features = false, features = ["bip39", "alloc", "secp256k1"] }
-cosmrs = "0.21"
+cosmrs = "0.21.1"
 chrono = { version = "0.4", features = ["serde"] }
 delegate = "0.13"
 derive_more.workspace = true

--- a/v4-client-rs/client/examples/authenticator.rs
+++ b/v4-client-rs/client/examples/authenticator.rs
@@ -1,0 +1,153 @@
+//! Permissioned keys/authenticators example.
+//! For more information see [the docs](https://docs.dydx.exchange/api_integration-guides/how_to_permissioned_keys).
+
+mod support;
+use anyhow::{Error, Result};
+use bigdecimal::BigDecimal;
+use dydx::config::ClientConfig;
+use dydx::indexer::{IndexerClient, Subaccount};
+use dydx::node::{
+    Account, AuthenticatorBuilder, NodeClient, OrderBuilder, OrderSide, PublicAccount, Wallet,
+};
+use dydx_proto::dydxprotocol::clob::order::TimeInForce;
+use std::str::FromStr;
+use support::constants::TEST_MNEMONIC;
+use tokio::time::{sleep, Duration};
+
+const ETH_USD_TICKER: &str = "ETH-USD";
+
+pub struct Trader {
+    client: NodeClient,
+    indexer: IndexerClient,
+    account: Account,
+}
+
+impl Trader {
+    pub async fn connect(index: u32) -> Result<Self> {
+        let config = ClientConfig::from_file("client/tests/testnet.toml").await?;
+        let mut client = NodeClient::connect(config.node).await?;
+        let indexer = IndexerClient::new(config.indexer);
+        let wallet = Wallet::from_mnemonic(TEST_MNEMONIC)?;
+        let account = wallet.account(index, &mut client).await?;
+        Ok(Self {
+            client,
+            indexer,
+            account,
+        })
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt().try_init().map_err(Error::msg)?;
+    #[cfg(feature = "telemetry")]
+    support::telemetry::metrics_dashboard().await?;
+
+    // We will just create two (isolated) accounts using the same mnemonic.
+    // In a more realistic setting each user would have its own mnemonic/wallet.
+    let mut master = Trader::connect(0).await?;
+    let master_address = master.account.address().clone();
+    let mut permissioned = Trader::connect(1).await?;
+
+    // -- Permissioning account actions --
+
+    log::info!("[master] Creating the authenticator.");
+
+    // For permissioned trading, the permissioned account needs an associated authenticator ID,
+    // created by the permissioning account.
+    // An authenticator declares the conditions/permissions that allow the permissioned account to
+    // trade under.
+    let authenticator = AuthenticatorBuilder::empty()
+        // The permissioned account needs to share its public key with the permissioning account.
+        // Through other channels, users can share their public keys using hex strings, e.g.,
+        // let keystring = hex::encode(&account.public_key().to_bytes())
+        // let bytes = hex::decode(&keystring);
+        .signature_verification(permissioned.account.public_key().to_bytes())
+        // The allowed actions
+        .filter_message(&["/dydxprotocol.clob.MsgPlaceOrder"])
+        // The allowed markets
+        .filter_clob_pair([0, 1])
+        // The allowed subaccounts
+        .filter_subaccount([0])?
+        // A transaction will only be accepted if all conditions above are satisfied.
+        // Alternatively, `.any_of()` can be used.
+        // If only one condition was declared, `.all_of()` or `.any_of()` should not be used.
+        .all_of()
+        .build()?;
+
+    // Broadcast the built authenticator.
+    master
+        .client
+        .authenticators()
+        .add(&mut master.account, master_address.clone(), authenticator)
+        .await?;
+
+    sleep(Duration::from_secs(3)).await;
+
+    // -- Permissioned account actions --
+
+    log::info!("[trader] Fetching the authenticator.");
+
+    // The permissioned account needs then to acquire the ID associated with the authenticator.
+    // Here, we will just grab the last authenticator ID pushed under the permissioning account.
+    let id = permissioned
+        .client
+        .authenticators()
+        .list(master_address.clone())
+        .await?
+        .last()
+        .unwrap()
+        .id;
+
+    // The permissioned account then adds that ID.
+    // An updated `PublicAccount` account, representing the permissioner, needs to be created.
+    let external_account =
+        PublicAccount::updated(master_address.clone(), &mut permissioned.client).await?;
+    permissioned
+        .account
+        .authenticators_mut()
+        .add(external_account, id);
+
+    let master_subaccount = Subaccount {
+        address: master_address.clone(),
+        number: 0.try_into()?,
+    };
+
+    log::info!("[trader] Creating the order. Using authenticator ID {id}.");
+
+    // Create an order as usual, however for the permissioning account's subaccount.
+    let market = permissioned
+        .indexer
+        .markets()
+        .get_perpetual_market(&ETH_USD_TICKER.into())
+        .await?;
+    let current_block_height = permissioned.client.get_latest_block_height().await?;
+
+    let size = BigDecimal::from_str("0.02")?;
+    let (_id, order) = OrderBuilder::new(market, master_subaccount)
+        .market(OrderSide::Buy, size)
+        .reduce_only(false)
+        .price(100) // market-order slippage protection price
+        .time_in_force(TimeInForce::Unspecified)
+        .until(current_block_height.ahead(10))
+        .build(123456)?;
+
+    let tx_hash = permissioned
+        .client
+        .place_order(&mut permissioned.account, order)
+        .await?;
+    tracing::info!("Broadcast transaction hash: {:?}", tx_hash);
+
+    // -- Permissioning account actions --
+
+    log::info!("[master] Removing the authenticator.");
+
+    // Authenticators can also be removed when not needed anymore
+    master
+        .client
+        .authenticators()
+        .remove(&mut master.account, master_address, id)
+        .await?;
+
+    Ok(())
+}

--- a/v4-client-rs/client/examples/withdraw_other.rs
+++ b/v4-client-rs/client/examples/withdraw_other.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<()> {
     .to_any();
     let simulated_tx = client
         .builder
-        .build_transaction(&account, once(msg), None)?;
+        .build_transaction(&account, once(msg), None, None)?;
     let simulation = client.simulate(&simulated_tx).await?;
     tracing::info!("Simulation: {:?}", simulation);
 
@@ -67,7 +67,7 @@ async fn main() -> Result<()> {
     .to_any();
     let final_tx = client
         .builder
-        .build_transaction(&account, once(final_msg), Some(fee))?;
+        .build_transaction(&account, once(final_msg), Some(fee), None)?;
     let tx_hash = client.broadcast_transaction(final_tx).await?;
     tracing::info!("Withdraw transaction hash: {:?}", tx_hash);
 

--- a/v4-client-rs/client/src/indexer/types.rs
+++ b/v4-client-rs/client/src/indexer/types.rs
@@ -170,6 +170,12 @@ impl From<u32> for ClobPairId {
     }
 }
 
+impl From<&u32> for ClobPairId {
+    fn from(value: &u32) -> Self {
+        ClobPairId::from(*value)
+    }
+}
+
 /// Client metadata.
 #[serde_as]
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -452,6 +458,13 @@ impl TryFrom<u32> for SubaccountNumber {
             0..=128_000 => Ok(SubaccountNumber(number)),
             _ => Err(err!("Subaccount number must be [0, 128_000]")),
         }
+    }
+}
+
+impl TryFrom<&u32> for SubaccountNumber {
+    type Error = Error;
+    fn try_from(number: &u32) -> Result<Self, Error> {
+        Self::try_from(*number)
     }
 }
 

--- a/v4-client-rs/client/src/indexer/types.rs
+++ b/v4-client-rs/client/src/indexer/types.rs
@@ -161,7 +161,7 @@ impl From<AnyId> for ClientId {
 
 /// Clob pair id.
 #[serde_as]
-#[derive(Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClobPairId(#[serde_as(as = "DisplayFromStr")] pub u32);
 
 impl From<u32> for ClobPairId {

--- a/v4-client-rs/client/src/noble/mod.rs
+++ b/v4-client-rs/client/src/noble/mod.rs
@@ -201,7 +201,7 @@ impl NobleClient {
 
         let tx_raw =
             self.builder
-                .build_transaction(account, std::iter::once(msg.to_any()), None)?;
+                .build_transaction(account, std::iter::once(msg.to_any()), None, None)?;
 
         let simulated = self.simulate(&tx_raw).await?;
         let gas = simulated.gas_used;
@@ -212,7 +212,7 @@ impl NobleClient {
             .map_err(|e| err!("Raw Tx to bytes failed: {e}"))?;
         let tx = Tx::from_bytes(&tx_bytes).map_err(|e| err!("Failed to decode Tx bytes: {e}"))?;
         self.builder
-            .build_transaction(account, tx.body.messages, Some(fee))?;
+            .build_transaction(account, tx.body.messages, Some(fee), None)?;
 
         let request = BroadcastTxRequest {
             tx_bytes: tx_raw

--- a/v4-client-rs/client/src/node/builder.rs
+++ b/v4-client-rs/client/src/node/builder.rs
@@ -51,7 +51,7 @@ impl TxBuilder {
         // Add authenticators, if present, as a Tx extension
         let mut authing = None;
         if let Some(address) = auth {
-            if let Some((acc, ids)) = account.authenticators().get(&address) {
+            if let Some((acc, ids)) = account.authenticators().get(address) {
                 let ext = TxExtension {
                     selected_authenticators: ids.clone(),
                 };

--- a/v4-client-rs/client/src/node/client/authenticator.rs
+++ b/v4-client-rs/client/src/node/client/authenticator.rs
@@ -1,0 +1,248 @@
+use super::*;
+
+use anyhow::{anyhow as err, bail, ensure, Error};
+use core::fmt;
+use dydx_proto::dydxprotocol::{
+    accountplus::{
+        AccountAuthenticator, GetAuthenticatorsRequest, GetAuthenticatorsResponse,
+        MsgAddAuthenticator, MsgRemoveAuthenticator,
+    },
+    subaccounts::SubaccountId,
+};
+use serde::{Deserialize, Serialize};
+
+/// [`NodeClient`] Authenticator requests dispatcher
+pub struct Authenticators<'a> {
+    client: &'a mut NodeClient,
+}
+
+///
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, Serialize, Deserialize)]
+pub enum AuthenticatorType {
+    ///
+    SignatureVerification,
+    ///
+    MessageFilter,
+    ///
+    ClobPairIdFilter,
+    ///
+    SubaccountFilter,
+}
+
+impl fmt::Display for AuthenticatorType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl<'a> Authenticators<'a> {
+    /// Create a new Authenticator requests dispatcher
+    pub(crate) fn new(client: &'a mut NodeClient) -> Self {
+        Self { client }
+    }
+
+    /// Add an authenticator.
+    ///
+    /// Check [the example]().
+    pub async fn add(
+        &mut self,
+        account: &mut Account,
+        address: Address,
+        authenticator: Authenticator,
+    ) -> Result<TxHash, NodeError> {
+        let client = &mut self.client;
+
+        authenticator.check()?;
+
+        let msg = MsgAddAuthenticator {
+            sender: address.into(),
+            authenticator_type: authenticator.type_to_string()?,
+            data: authenticator.config_to_bytes()?,
+        };
+
+        let tx_raw = client.create_transaction(account, msg, None).await?;
+
+        client.broadcast_transaction(tx_raw).await
+    }
+
+    /// Remove an authenticator.
+    ///
+    /// Check [the example]().
+    pub async fn remove(
+        &mut self,
+        account: &mut Account,
+        address: Address,
+        id: u64,
+    ) -> Result<TxHash, NodeError> {
+        let client = &mut self.client;
+
+        let msg = MsgRemoveAuthenticator {
+            sender: address.into(),
+            id,
+        };
+
+        let tx_raw = client.create_transaction(account, msg, None).await?;
+
+        client.broadcast_transaction(tx_raw).await
+    }
+
+    /// List authenticators.
+    ///
+    /// Check [the example]().
+    pub async fn list(&mut self, address: Address) -> Result<Vec<AccountAuthenticator>, Error> {
+        let client = &mut self.client;
+
+        let req = GetAuthenticatorsRequest {
+            account: address.into(),
+        };
+
+        let response = client
+            .accountplus
+            .get_authenticators(req)
+            .await?
+            .into_inner();
+
+        Ok(response.account_authenticators)
+    }
+}
+
+///
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub(crate) struct AuthenticatorEntry {
+    #[serde(rename = "type")]
+    ty: AuthenticatorType,
+    config: Vec<u8>,
+}
+
+///
+#[derive(Debug, Clone)]
+pub(crate) enum AuthenticatorComposableType {
+    AnyOf,
+    AllOf,
+    Single,
+}
+
+impl fmt::Display for AuthenticatorComposableType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+///
+#[derive(Debug, Clone)]
+pub struct Authenticator {
+    pub(crate) composable: AuthenticatorComposableType,
+    pub(crate) config: Vec<AuthenticatorEntry>,
+}
+
+impl Authenticator {
+    /// Self integrity check
+    pub(super) fn check(&self) -> Result<()> {
+        if self.config.is_empty() {
+            return Err(err!("Authenticator methods are empty").into());
+        }
+        match self.composable {
+            AuthenticatorComposableType::AllOf | AuthenticatorComposableType::AnyOf => {
+                if self.config.len() < 2 {
+                    return Err(err!(
+                        "{:?} authenticator must have at least 2 sub-authenticators",
+                        self.composable
+                    )
+                    .into());
+                }
+            }
+            _ => (),
+        }
+        Ok(())
+    }
+
+    ///
+    pub(super) fn type_to_string(&self) -> Result<String> {
+        match self.composable {
+            AuthenticatorComposableType::AllOf | AuthenticatorComposableType::AnyOf => {
+                Ok(self.composable.to_string())
+            }
+            AuthenticatorComposableType::Single => {
+                // Use the first entry
+                self.config.iter().next().map(|entry| entry.ty.to_string()).ok_or_else(|| err!("Authenticator must contain at least one authenticator method if not composable"))
+            }
+        }
+    }
+
+    ///
+    pub(super) fn config_to_bytes(&self) -> Result<Vec<u8>> {
+        match self.composable {
+            AuthenticatorComposableType::AllOf | AuthenticatorComposableType::AnyOf => {
+                Ok(serde_json::to_string(&self.config)?.into_bytes())
+            }
+            AuthenticatorComposableType::Single => {
+                // Use the first entry
+                self.config.iter().next().map(|entry| entry.config.clone()).ok_or_else(|| err!("Authenticator must contain at least one authenticator method if not composable"))
+            }
+        }
+    }
+}
+
+/// Authenticator builder
+#[derive(Debug, Clone)]
+pub struct AuthenticatorBuilder {
+    auth: Authenticator,
+}
+
+impl AuthenticatorBuilder {
+    ///
+    pub fn empty() -> Self {
+        Self {
+            auth: Authenticator {
+                composable: AuthenticatorComposableType::Single,
+                config: Vec::new(),
+            },
+        }
+    }
+
+    /// Sets the authenticator as "any of"
+    pub fn any_of(&mut self) -> &mut Self {
+        self.auth.composable = AuthenticatorComposableType::AnyOf;
+        self
+    }
+
+    /// Sets the authenticator as "all of"
+    pub fn all_of(&mut self) -> &mut Self {
+        self.auth.composable = AuthenticatorComposableType::AllOf;
+        self
+    }
+
+    /// Add an authentication method
+    pub fn add(
+        &mut self,
+        authenticator_type: AuthenticatorType,
+        data: impl Into<Vec<u8>>,
+    ) -> &mut Self {
+        self.auth.config.push(AuthenticatorEntry {
+            ty: authenticator_type,
+            config: data.into(),
+        });
+        self
+    }
+
+    /// Finalizes the builder, constructing an [`Authenticator`]
+    pub fn build(&self) -> Result<Authenticator> {
+        self.try_into()
+    }
+}
+
+impl TryFrom<AuthenticatorBuilder> for Authenticator {
+    type Error = Error;
+    fn try_from(builder: AuthenticatorBuilder) -> Result<Self> {
+        builder.auth.check()?;
+        Ok(builder.auth)
+    }
+}
+
+impl TryFrom<&AuthenticatorBuilder> for Authenticator {
+    type Error = Error;
+    fn try_from(builder: &AuthenticatorBuilder) -> Result<Self> {
+        builder.auth.check()?;
+        Ok(builder.auth.clone())
+    }
+}

--- a/v4-client-rs/client/src/node/client/authenticators.rs
+++ b/v4-client-rs/client/src/node/client/authenticators.rs
@@ -42,7 +42,7 @@ impl<'a> Authenticators<'a> {
     /// Add an [`Authenticator`].
     /// Authenticators can be built using the [`AuthenticatorBuilder`] mechanism.
     ///
-    /// Check [the example]().
+    /// Check [the example](https://github.com/dydxprotocol/v4-clients/blob/main/v4-client-rs/client/examples/authenticator.rs).
     pub async fn add(
         &mut self,
         account: &mut Account,
@@ -66,7 +66,7 @@ impl<'a> Authenticators<'a> {
 
     /// Remove an authenticator.
     ///
-    /// Check [the example]().
+    /// Check [the example](https://github.com/dydxprotocol/v4-clients/blob/main/v4-client-rs/client/examples/authenticator.rs).
     pub async fn remove(
         &mut self,
         account: &mut Account,
@@ -87,7 +87,7 @@ impl<'a> Authenticators<'a> {
 
     /// List authenticators.
     ///
-    /// Check [the example]().
+    /// Check [the example](https://github.com/dydxprotocol/v4-clients/blob/main/v4-client-rs/client/examples/authenticator.rs).
     pub async fn list(&mut self, address: Address) -> Result<Vec<AccountAuthenticator>, Error> {
         let client = &mut self.client;
 
@@ -182,6 +182,8 @@ impl Authenticator {
 }
 
 /// [`Authenticator`] builder.
+///
+/// See the [example](https://github.com/dydxprotocol/v4-clients/blob/main/v4-client-rs/client/examples/authenticator.rs).
 #[derive(Debug, Clone)]
 pub struct AuthenticatorBuilder {
     auth: Authenticator,

--- a/v4-client-rs/client/src/node/client/authenticators.rs
+++ b/v4-client-rs/client/src/node/client/authenticators.rs
@@ -8,7 +8,7 @@ use dydx_proto::dydxprotocol::accountplus::{
 };
 use serde::{Deserialize, Serialize};
 
-/// [`NodeClient`] Authenticator requests dispatcher
+/// [`NodeClient`] Authenticator requests dispatcher.
 pub struct Authenticators<'a> {
     client: &'a mut NodeClient,
 }

--- a/v4-client-rs/client/src/node/client/megavault.rs
+++ b/v4-client-rs/client/src/node/client/megavault.rs
@@ -51,7 +51,7 @@ impl<'a> MegaVault<'a> {
             quote_quantums: quantums,
         };
 
-        let tx_raw = client.create_transaction(account, msg).await?;
+        let tx_raw = client.create_transaction(account, msg, None).await?;
 
         client.broadcast_transaction(tx_raw).await
     }
@@ -91,7 +91,7 @@ impl<'a> MegaVault<'a> {
             shares: num_shares,
         };
 
-        let tx_raw = client.create_transaction(account, msg).await?;
+        let tx_raw = client.create_transaction(account, msg, None).await?;
 
         client.broadcast_transaction(tx_raw).await
     }

--- a/v4-client-rs/client/src/node/client/mod.rs
+++ b/v4-client-rs/client/src/node/client/mod.rs
@@ -3,7 +3,7 @@ pub mod error;
 mod megavault;
 mod methods;
 
-pub use self::authenticators::{AuthenticatorBuilder, AuthenticatorType};
+pub use self::authenticators::{Authenticator, AuthenticatorBuilder, AuthenticatorType};
 use self::{authenticators::Authenticators, megavault::MegaVault};
 use super::{
     builder::TxBuilder, config::NodeConfig, order::*, sequencer::*, utils::*, wallet::Account,

--- a/v4-client-rs/client/src/node/client/mod.rs
+++ b/v4-client-rs/client/src/node/client/mod.rs
@@ -88,7 +88,7 @@ pub type TxHash = String;
 /// Wrapper over standard [Cosmos modules](https://github.com/cosmos/cosmos-sdk/tree/main/x) clients
 /// and [dYdX modules](https://github.com/dydxprotocol/v4-chain/tree/main/protocol/x) clients.
 pub struct Routes {
-    ///
+    /// Smart account features, includes authenticators.
     pub accountplus: AccountPlusClient<Timeout<Channel>>,
     /// Authentication of accounts and transactions for Cosmos SDK applications.
     pub auth: AuthClient<Timeout<Channel>>,
@@ -626,9 +626,9 @@ impl NodeClient {
     ) -> Result<tx::Raw, Error> {
         if seqnum_required && self.config.manage_sequencing {
             if let Some(authing) = auth {
-                if let Some((acc, _)) = account.authenticators_mut().get_mut(&authing) {
-                    let nonce = self.sequencer.next_nonce(acc.address()).await?;
-                    acc.set_next_nonce(nonce);
+                if let Some((master, _)) = account.authenticators_mut().get_mut(authing) {
+                    let nonce = self.sequencer.next_nonce(master.address()).await?;
+                    master.set_next_nonce(nonce);
                 }
             } else {
                 let nonce = self.sequencer.next_nonce(account.address()).await?;
@@ -636,8 +636,8 @@ impl NodeClient {
             }
         } else if !seqnum_required {
             if let Some(authing) = auth {
-                if let Some((acc, _)) = account.authenticators_mut().get_mut(&authing) {
-                    acc.set_next_nonce(Nonce::Sequence(acc.sequence_number()));
+                if let Some((master, _)) = account.authenticators_mut().get_mut(authing) {
+                    master.set_next_nonce(Nonce::Sequence(master.sequence_number()));
                 }
             } else {
                 account.set_next_nonce(Nonce::Sequence(account.sequence_number()));

--- a/v4-client-rs/client/src/node/client/mod.rs
+++ b/v4-client-rs/client/src/node/client/mod.rs
@@ -3,7 +3,7 @@ pub mod error;
 mod megavault;
 mod methods;
 
-pub use self::authenticators::{Authenticator, AuthenticatorBuilder, AuthenticatorType};
+pub use self::authenticators::Authenticator;
 use self::{authenticators::Authenticators, megavault::MegaVault};
 use super::{
     builder::TxBuilder, config::NodeConfig, order::*, sequencer::*, utils::*, wallet::Account,

--- a/v4-client-rs/client/src/node/client/mod.rs
+++ b/v4-client-rs/client/src/node/client/mod.rs
@@ -539,7 +539,9 @@ impl NodeClient {
         MegaVault::new(self)
     }
 
-    /// Access the authenticators/permissioned keys requests dispatcher
+    /// Access the authenticators/permissioned keys requests dispatcher.
+    ///
+    /// See the [example](https://github.com/dydxprotocol/v4-clients/blob/main/v4-client-rs/client/examples/authenticator.rs).
     pub fn authenticators(&mut self) -> Authenticators {
         Authenticators::new(self)
     }

--- a/v4-client-rs/client/src/node/config.rs
+++ b/v4-client-rs/client/src/node/config.rs
@@ -29,7 +29,7 @@ pub struct NodeConfig {
 }
 
 fn default_timeout() -> u64 {
-    1_000
+    2_000
 }
 
 fn default_manage_sequencing() -> bool {

--- a/v4-client-rs/client/src/node/fee.rs
+++ b/v4-client-rs/client/src/node/fee.rs
@@ -8,7 +8,7 @@ use bigdecimal::{
 use cosmrs::{tx::Fee, Coin};
 
 /// Gas ajdustement value to avoid rejected transactions caused by gas understimation.
-const GAS_MULTIPLIER: f64 = 1.7;
+const GAS_MULTIPLIER: f64 = 1.8;
 
 pub(crate) fn default() -> Fee {
     Fee {

--- a/v4-client-rs/client/src/node/fee.rs
+++ b/v4-client-rs/client/src/node/fee.rs
@@ -8,7 +8,7 @@ use bigdecimal::{
 use cosmrs::{tx::Fee, Coin};
 
 /// Gas ajdustement value to avoid rejected transactions caused by gas understimation.
-const GAS_MULTIPLIER: f64 = 1.4;
+const GAS_MULTIPLIER: f64 = 1.7;
 
 pub(crate) fn default() -> Fee {
     Fee {

--- a/v4-client-rs/client/src/node/mod.rs
+++ b/v4-client-rs/client/src/node/mod.rs
@@ -10,7 +10,9 @@ mod utils;
 mod wallet;
 
 pub use builder::TxBuilder;
-pub use client::{authenticator, error::*, Address, NodeClient, Subaccount, TxHash};
+pub use client::{
+    error::*, Address, AuthenticatorBuilder, AuthenticatorType, NodeClient, Subaccount, TxHash,
+};
 pub use config::NodeConfig;
 pub use order::*;
 pub use types::ChainId;

--- a/v4-client-rs/client/src/node/mod.rs
+++ b/v4-client-rs/client/src/node/mod.rs
@@ -10,9 +10,9 @@ mod utils;
 mod wallet;
 
 pub use builder::TxBuilder;
-pub use client::{error::*, Address, NodeClient, Subaccount, TxHash};
+pub use client::{authenticator, error::*, Address, NodeClient, Subaccount, TxHash};
 pub use config::NodeConfig;
 pub use order::*;
 pub use types::ChainId;
 pub use utils::BigIntExt;
-pub use wallet::{Account, Wallet};
+pub use wallet::{Account, PublicAccount, Wallet};

--- a/v4-client-rs/client/src/node/mod.rs
+++ b/v4-client-rs/client/src/node/mod.rs
@@ -11,7 +11,8 @@ mod wallet;
 
 pub use builder::TxBuilder;
 pub use client::{
-    error::*, Address, AuthenticatorBuilder, AuthenticatorType, NodeClient, Subaccount, TxHash,
+    error::*, Address, Authenticator, AuthenticatorBuilder, AuthenticatorType, NodeClient,
+    Subaccount, TxHash,
 };
 pub use config::NodeConfig;
 pub use order::*;

--- a/v4-client-rs/client/src/node/mod.rs
+++ b/v4-client-rs/client/src/node/mod.rs
@@ -10,10 +10,7 @@ mod utils;
 mod wallet;
 
 pub use builder::TxBuilder;
-pub use client::{
-    error::*, Address, Authenticator, AuthenticatorBuilder, AuthenticatorType, NodeClient,
-    Subaccount, TxHash,
-};
+pub use client::{error::*, Address, Authenticator, NodeClient, Subaccount, TxHash};
 pub use config::NodeConfig;
 pub use order::*;
 pub use types::ChainId;

--- a/v4-client-rs/client/src/node/sequencer.rs
+++ b/v4-client-rs/client/src/node/sequencer.rs
@@ -15,7 +15,7 @@ use tonic::{transport::Channel, Request};
 use tower::timeout::Timeout;
 
 /// Transaction sequence number validation value used to enable protection against replay attacks.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Nonce {
     /// A sequence number is incremental, associated with the number of transactions (short-term
     /// orders excluded) issued by an [`Account`](super::wallet::Account).

--- a/v4-client-rs/client/tests/test_node_authenticators.rs
+++ b/v4-client-rs/client/tests/test_node_authenticators.rs
@@ -1,0 +1,146 @@
+mod env;
+use env::TestEnv;
+
+use anyhow::Error;
+use bigdecimal::BigDecimal;
+use dydx::node::*;
+use rand::{thread_rng, Rng};
+use serial_test::serial;
+use std::str::FromStr;
+use tokio::time::{sleep, Duration};
+
+#[tokio::test]
+async fn test_node_auth_list() -> Result<(), Error> {
+    let env = TestEnv::testnet().await?;
+    let mut node = env.node;
+    let account = env.account;
+
+    node.authenticators()
+        .list(account.address().clone())
+        .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_node_auth_add_allof() -> Result<(), Error> {
+    let env = TestEnv::testnet().await?;
+    let mut node = env.node;
+    let mut account = env.account;
+    let address = account.address().clone();
+    let paccount = env.wallet.account_offline(1)?;
+
+    let authenticator = AuthenticatorBuilder::empty()
+        .all_of()
+        .signature_verification(paccount.public_key().to_bytes())
+        .filter_message(&["/dydxprotocol.clob.MsgPlaceOrder"])
+        .filter_subaccount([0])?
+        .filter_clob_pair([0, 1])
+        .build()?;
+    println!("authenticator: {authenticator:?}");
+    node.authenticators()
+        .add(&mut account, address, authenticator)
+        .await?;
+
+    sleep(Duration::from_secs(3)).await;
+
+    let list = node
+        .authenticators()
+        .list(account.address().clone())
+        .await?;
+    assert!(!list.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_node_auth_add_single() -> Result<(), Error> {
+    let env = TestEnv::testnet().await?;
+    let mut node = env.node;
+    let mut account = env.account;
+    let address = account.address().clone();
+    let paccount = env.wallet.account_offline(1)?;
+
+    let authenticator = AuthenticatorBuilder::empty()
+        .signature_verification(paccount.public_key().to_bytes())
+        .filter_message(&["/dydxprotocol.clob.MsgPlaceOrder"])
+        .build()?;
+    node.authenticators()
+        .add(&mut account, address, authenticator)
+        .await?;
+
+    sleep(Duration::from_secs(3)).await;
+
+    let list = node
+        .authenticators()
+        .list(account.address().clone())
+        .await?;
+    assert!(!list.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_node_auth_place_order_short_term() -> Result<(), Error> {
+    let env = TestEnv::testnet().await?;
+    let market = env.get_market().await?;
+    let height = env.get_height().await?;
+    let mut node = env.node;
+    let mut account = env.account;
+    let address = account.address().clone();
+    let mut paccount = env.wallet.account(1, &mut node).await?;
+
+    // Add authenticator
+    let authenticator = AuthenticatorBuilder::empty()
+        .signature_verification(paccount.public_key().to_bytes())
+        .filter_message(&["/dydxprotocol.clob.MsgPlaceOrder"])
+        .all_of()
+        .build()?;
+    node.authenticators()
+        .add(&mut account, address.clone(), authenticator)
+        .await?;
+
+    sleep(Duration::from_secs(3)).await;
+
+    // Grab last authenticator ID
+    let list = node.authenticators().list(address.clone()).await?;
+    let master = PublicAccount::updated(account.address().clone(), &mut node).await?;
+    paccount
+        .authenticators_mut()
+        .add(master, list.last().unwrap().id);
+
+    // Create order for permissioning account
+    let (_, order) = OrderBuilder::new(market, account.subaccount(0)?)
+        .market(OrderSide::Buy, BigDecimal::from_str("0.001")?)
+        .price(10) // Low slippage price to not execute
+        .until(height.ahead(10))
+        .build(thread_rng().gen_range(0..100_000_000))?;
+
+    // Push order by permissioned account
+    node.place_order(&mut paccount, order).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_node_auth_remove() -> Result<(), Error> {
+    let env = TestEnv::testnet().await?;
+    let mut node = env.node;
+    let mut account = env.account;
+    let address = account.address().clone();
+
+    let list = node.authenticators().list(address.clone()).await?;
+    // Lets take the opportunity here and remove a few
+    for auth in list.iter().rev().take(5) {
+        node.authenticators()
+            .remove(&mut account, address.clone(), auth.id)
+            .await?;
+        sleep(Duration::from_secs(3)).await;
+    }
+
+    Ok(())
+}

--- a/v4-client-rs/client/tests/test_node_authenticators.rs
+++ b/v4-client-rs/client/tests/test_node_authenticators.rs
@@ -31,14 +31,12 @@ async fn test_node_auth_add_allof() -> Result<(), Error> {
     let address = account.address().clone();
     let paccount = env.wallet.account_offline(1)?;
 
-    let authenticator = AuthenticatorBuilder::empty()
-        .all_of()
-        .signature_verification(paccount.public_key().to_bytes())
-        .filter_message(&["/dydxprotocol.clob.MsgPlaceOrder"])
-        .filter_subaccount([0])?
-        .filter_clob_pair([0, 1])
-        .build()?;
-    println!("authenticator: {authenticator:?}");
+    let authenticator = Authenticator::AllOf(vec![
+        Authenticator::SignatureVerification(paccount.public_key().to_bytes()),
+        Authenticator::MessageFilter("dydxprotocol.clob.MsgPlaceOrder".into()),
+        Authenticator::SubaccountFilter("0".into()),
+        Authenticator::ClobPairIdFilter("0,1".into()),
+    ]);
     node.authenticators()
         .add(&mut account, address, authenticator)
         .await?;
@@ -63,10 +61,7 @@ async fn test_node_auth_add_single() -> Result<(), Error> {
     let address = account.address().clone();
     let paccount = env.wallet.account_offline(1)?;
 
-    let authenticator = AuthenticatorBuilder::empty()
-        .signature_verification(paccount.public_key().to_bytes())
-        .filter_message(&["/dydxprotocol.clob.MsgPlaceOrder"])
-        .build()?;
+    let authenticator = Authenticator::SignatureVerification(paccount.public_key().to_bytes());
     node.authenticators()
         .add(&mut account, address, authenticator)
         .await?;
@@ -94,11 +89,10 @@ async fn test_node_auth_place_order_short_term() -> Result<(), Error> {
     let mut paccount = env.wallet.account(1, &mut node).await?;
 
     // Add authenticator
-    let authenticator = AuthenticatorBuilder::empty()
-        .signature_verification(paccount.public_key().to_bytes())
-        .filter_message(&["/dydxprotocol.clob.MsgPlaceOrder"])
-        .all_of()
-        .build()?;
+    let authenticator = Authenticator::AllOf(vec![
+        Authenticator::SignatureVerification(paccount.public_key().to_bytes()),
+        Authenticator::MessageFilter("/dydxprotocol.clob.MsgPlaceOrder".into()),
+    ]);
     node.authenticators()
         .add(&mut account, address.clone(), authenticator)
         .await?;


### PR DESCRIPTION
Permissionless key implementation.
Interface for the permissioning account is through `NodeClient::authenticators()` for gRPC requests.
Interface for the permissioned account is through `Account::authenticators()`.

Closes #318.

Had to increase fee adjustment multiplier a bit (from `1.4` to `1.8`). While the TS client has it at `1.6`, some transactions were being rejected at this value here. Issue #320 may be related.

(edit: ready) Awaiting on a `cosmrs` release which fixes a [small issue](https://github.com/cosmos/cosmos-rust/pull/516) related with non-critical Tx extensions.
