### PR TITLE
feat: Add functionality to validate authenticators added my clients

### DIFF
--- a/v4-client-js/__tests__/clients/composite-client.test.ts
+++ b/v4-client-js/__tests__/clients/composite-client.test.ts
@@ -1,0 +1,140 @@
+import { Authenticator, AuthenticatorType, Network } from '../../src';
+import { CompositeClient } from '../../src/clients/composite-client'
+
+describe('CompositeClient', () => {
+  describe('validateAuthenticators', () => {
+    const network = Network.staging();
+
+    it('Validates top level AnyOf authenticators', async () => {
+      const client = await CompositeClient.connect(network);
+      const auth: Authenticator = {
+        type: AuthenticatorType.ANY_OF,
+        config: [
+          { type: AuthenticatorType.SIGNATURE_VERIFICATION, config: "" },
+          { type: AuthenticatorType.SIGNATURE_VERIFICATION, config: "" },
+        ],
+      }
+      expect(client.validateAuthenticator(auth)).toEqual(true);
+    });
+
+    it('Fails top level AnyOf authenticators with non-signature nested authenticator', async () => {
+      const client = await CompositeClient.connect(network);
+      const auth: Authenticator = {
+        type: AuthenticatorType.ANY_OF,
+        config: [
+          { type: AuthenticatorType.SIGNATURE_VERIFICATION, config: "" },
+          { type: AuthenticatorType.MESSAGE_FILTER, config: "" },
+        ],
+      }
+      expect(client.validateAuthenticator(auth)).toEqual(false);
+    });
+
+    it('Validates top level AllOf authenticators', async () => {
+      const client = await CompositeClient.connect(network);
+      const auth: Authenticator = {
+        type: AuthenticatorType.ALL_OF,
+        config: [
+          { type: AuthenticatorType.SIGNATURE_VERIFICATION, config: "" },
+          { type: AuthenticatorType.MESSAGE_FILTER, config: "" },
+        ],
+      }
+      expect(client.validateAuthenticator(auth)).toEqual(true);
+    });
+
+    it('Fails top level AllOf authenticators, without signature verification', async () => {
+      const client = await CompositeClient.connect(network);
+      const auth: Authenticator = {
+        type: AuthenticatorType.ALL_OF,
+        config: [
+          { type: AuthenticatorType.MESSAGE_FILTER, config: "" },
+          { type: AuthenticatorType.MESSAGE_FILTER, config: "" },
+        ],
+      }
+      expect(client.validateAuthenticator(auth)).toEqual(false);
+    });
+
+    it('Validates nested anyOf authenticators', async () => {
+      const client = await CompositeClient.connect(network);
+      const nestedAnyOf =  {
+        type: AuthenticatorType.ANY_OF,
+        config: [
+          { type: AuthenticatorType.MESSAGE_FILTER, config: "" },
+          { type: AuthenticatorType.MESSAGE_FILTER, config: "" },
+        ]
+      }
+      const signatureVerification = {
+        type: AuthenticatorType.SIGNATURE_VERIFICATION,
+        config: ""
+      }
+
+      const auth: Authenticator = {
+        type: AuthenticatorType.ALL_OF,
+        config: [signatureVerification, nestedAnyOf],
+      };
+      expect(client.validateAuthenticator(auth)).toEqual(true);
+    });
+
+    it('Validates nested allOf authenticators', async () => {
+      const client = await CompositeClient.connect(network);
+      const nestedAllOf =  {
+        type: AuthenticatorType.ALL_OF,
+        config: [
+          { type: AuthenticatorType.SIGNATURE_VERIFICATION, config: "" },
+          { type: AuthenticatorType.SIGNATURE_VERIFICATION, config: "" },
+        ]
+      }
+      const messageVerification = {
+        type: AuthenticatorType.MESSAGE_FILTER,
+        config: ""
+      }
+
+      const auth: Authenticator = {
+        type: AuthenticatorType.ALL_OF,
+        config: [messageVerification, nestedAllOf],
+      };
+      expect(client.validateAuthenticator(auth)).toEqual(true);
+    });
+
+    it('Fails nested anyOf signatureVerification authenticators', async () => {
+      const client = await CompositeClient.connect(network);
+      const nestedAnyOf =  {
+        type: AuthenticatorType.ANY_OF,
+        config: [
+          { type: AuthenticatorType.MESSAGE_FILTER, config: "" },
+          { type: AuthenticatorType.SIGNATURE_VERIFICATION, config: "" },
+        ]
+      }
+      const messageVerification = {
+        type: AuthenticatorType.MESSAGE_FILTER,
+        config: ""
+      }
+
+      const auth: Authenticator = {
+        type: AuthenticatorType.ALL_OF,
+        config: [messageVerification, nestedAnyOf],
+      };
+      expect(client.validateAuthenticator(auth)).toEqual(false);
+    });
+
+    it('Fails nested anyOf authenticators', async () => {
+      const client = await CompositeClient.connect(network);
+      const nestedAnyOf =  {
+        type: AuthenticatorType.ANY_OF,
+        config: [
+          { type: AuthenticatorType.MESSAGE_FILTER, config: "" },
+          { type: AuthenticatorType.SIGNATURE_VERIFICATION, config: "" },
+        ]
+      }
+      const messageVerification = {
+        type: AuthenticatorType.MESSAGE_FILTER,
+        config: ""
+      }
+
+      const auth: Authenticator = {
+        type: AuthenticatorType.ANY_OF,
+        config: [messageVerification, nestedAnyOf],
+      };
+      expect(client.validateAuthenticator(auth)).toEqual(false);
+    });
+  });
+});

--- a/v4-client-js/examples/permissioned_keys_example.ts
+++ b/v4-client-js/examples/permissioned_keys_example.ts
@@ -55,21 +55,38 @@ async function removeAuthenticator(
   await client.removeAuthenticator(subaccount, id);
 }
 
-async function addAuthenticator(client: CompositeClient, subaccount: SubaccountInfo, authedPubKey:string): Promise<void> {
-  const subAuthenticators = [{
+async function addAuthenticator(
+  client: CompositeClient,
+  subaccount: SubaccountInfo,
+  authedPubKey: string,
+): Promise<void> {
+  const subAuth = [ {
     type: AuthenticatorType.SIGNATURE_VERIFICATION,
     config: authedPubKey,
   },
   {
-    type: AuthenticatorType.MESSAGE_FILTER,
-    config: toBase64(new TextEncoder().encode("/dydxprotocol.clob.MsgPlaceOrder")),
-  },
+    type: AuthenticatorType.ANY_OF,
+    config: [
+    {
+      type: AuthenticatorType.MESSAGE_FILTER,
+      config: toBase64(new TextEncoder().encode('/dydxprotocol.clob.MsgPlaceOrder')),
+    },
+    {
+      type: AuthenticatorType.MESSAGE_FILTER,
+      config: toBase64(new TextEncoder().encode('/dydxprotocol.clob.MsgPlaceOrder')),
+    },
+    ]
+  }
 ];
 
-  const jsonString = JSON.stringify(subAuthenticators);
+  const jsonString = JSON.stringify(subAuth);
   const encodedData = new TextEncoder().encode(jsonString);
 
-  await client.addAuthenticator(subaccount, AuthenticatorType.ALL_OF, encodedData);
+  try {
+    await client.addAuthenticator(subaccount, AuthenticatorType.ALL_OF, encodedData);
+  } catch (error) {
+    console.log(error.message);
+  }
 }
 
 async function placeOrder(

--- a/v4-client-js/examples/permissioned_keys_example.ts
+++ b/v4-client-js/examples/permissioned_keys_example.ts
@@ -47,7 +47,11 @@ async function test(): Promise<void> {
   await placeOrder(client, subaccount2, subaccount1, authenticatorID);
 }
 
-async function removeAuthenticator(client: CompositeClient,subaccount: SubaccountInfo, id: Long): Promise<void> {
+async function removeAuthenticator(
+  client: CompositeClient,
+  subaccount: SubaccountInfo,
+  id: Long,
+): Promise<void> {
   await client.removeAuthenticator(subaccount, id);
 }
 
@@ -68,10 +72,15 @@ async function addAuthenticator(client: CompositeClient, subaccount: SubaccountI
   await client.addAuthenticator(subaccount, AuthenticatorType.ALL_OF, encodedData);
 }
 
-async function placeOrder(client: CompositeClient, fromAccount: SubaccountInfo, forAccount: SubaccountInfo, authenticatorId: Long): Promise<void> {
+async function placeOrder(
+  client: CompositeClient,
+  fromAccount: SubaccountInfo,
+  forAccount: SubaccountInfo,
+  authenticatorId: Long,
+): Promise<void> {
   try {
-    const side = OrderSide.BUY
-    const price = Number("1000");
+    const side = OrderSide.BUY;
+    const price = Number('1000');
     const currentBlock = await client.validatorClient.get.latestBlockHeight();
     const nextValidBlockHeight = currentBlock + 5;
     const goodTilBlock = nextValidBlockHeight + 10;
@@ -94,7 +103,7 @@ async function placeOrder(client: CompositeClient, fromAccount: SubaccountInfo, 
       {
         authenticators: [authenticatorId],
         accountForOrder: forAccount,
-      }
+      },
     );
     console.log('**Order Tx**');
     console.log(Buffer.from(tx.hash).toString('hex'));

--- a/v4-client-js/package-lock.json
+++ b/v4-client-js/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@dydxprotocol/v4-client-js",
-      "version": "1.3.15",
+      "version": "1.3.16",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.1",

--- a/v4-client-js/src/clients/composite-client.ts
+++ b/v4-client-js/src/clients/composite-client.ts
@@ -1279,24 +1279,24 @@ export class CompositeClient {
   validateAuthenticator(authenticator: Authenticator): boolean {
     function checkAuthenticator(auth: Authenticator): boolean {
       if (auth.type === AuthenticatorType.SIGNATURE_VERIFICATION) {
-        return true; // A SignatureVerification authenticator is valid
+        return true; // A SignatureVerification authenticator is safe.
       }
 
       if (!Array.isArray(auth.config)) {
-        return false; // Invalid case: a non-array config for a composite authenticator
+        return false; // Unsafe case: a non-array config for a composite authenticator
       }
 
       if (auth.type === AuthenticatorType.ANY_OF) {
-        // ANY_OF is valid only if ALL sub-authenticators return true
+        // ANY_OF is safe only if ALL sub-authenticators return true
         return auth.config.every((nestedAuth) => checkAuthenticator(nestedAuth));
       }
 
       if (auth.type === AuthenticatorType.ALL_OF) {
-        // ALL_OF is valid if at least one sub-authenticator returns true
+        // ALL_OF is safe if at least one sub-authenticator returns true
         return auth.config.some((nestedAuth) => checkAuthenticator(nestedAuth));
       }
 
-      // If it's a base-case authenticator but not SignatureVerification, it's invalid
+      // If it's a base-case authenticator but not SignatureVerification, it's unsafe
       return false;
     }
 

--- a/v4-client-js/src/clients/constants.ts
+++ b/v4-client-js/src/clients/constants.ts
@@ -211,6 +211,11 @@ export enum AuthenticatorType {
   SUBACCOUNT_FILTER = 'SubaccountFilter',
 }
 
+export interface Authenticator {
+  type: AuthenticatorType;
+  config: string | Authenticator[];
+}
+
 export enum TradingRewardAggregationPeriod {
   DAILY = 'DAILY',
   WEEKLY = 'WEEKLY',


### PR DESCRIPTION
Authenticators can be easily misused. This code adds an `validateAuthenticator` function that does some rudimentary checks to ensure that users are adding a signatureVerification authenticator as part of any combination of authenticators that are added. 