### PR TITLE
fix(noble): dYdX<->Noble transfers seqnum, `NobleUsdc` ergonomics

### DIFF
--- a/v4-client-rs/client/src/noble/mod.rs
+++ b/v4-client-rs/client/src/noble/mod.rs
@@ -2,12 +2,12 @@ mod config;
 mod tokens;
 use crate::{
     indexer::{Address, Denom, Tokenized},
-    node::{Account, TxBuilder, TxHash},
+    node::{sequencer::Nonce, Account, TxBuilder, TxHash},
 };
 use anyhow::{anyhow as err, Error};
 use chrono::{TimeDelta, Utc};
 pub use config::NobleConfig;
-use cosmrs::tx::{self, Tx};
+use cosmrs::tx;
 use dydx_proto::{
     cosmos_sdk_proto::cosmos::{
         auth::v1beta1::{
@@ -196,23 +196,26 @@ impl NobleClient {
 
         if self.config.manage_sequencing {
             let (_, sequence_number) = self.query_address(account.address()).await?;
-            account.set_sequence_number(sequence_number);
+            account.set_next_nonce(Nonce::Sequence(sequence_number));
         }
 
-        let tx_raw =
-            self.builder
-                .build_transaction(account, std::iter::once(msg.to_any()), None, None)?;
+        let tx_raw = self.builder.build_transaction(
+            account,
+            std::iter::once(msg.clone().to_any()),
+            None,
+            None,
+        )?;
 
         let simulated = self.simulate(&tx_raw).await?;
         let gas = simulated.gas_used;
         let fee = self.builder.calculate_fee(Some(gas))?;
 
-        let tx_bytes = tx_raw
-            .to_bytes()
-            .map_err(|e| err!("Raw Tx to bytes failed: {e}"))?;
-        let tx = Tx::from_bytes(&tx_bytes).map_err(|e| err!("Failed to decode Tx bytes: {e}"))?;
-        self.builder
-            .build_transaction(account, tx.body.messages, Some(fee), None)?;
+        let tx_raw = self.builder.build_transaction(
+            account,
+            std::iter::once(msg.to_any()),
+            Some(fee),
+            None,
+        )?;
 
         let request = BroadcastTxRequest {
             tx_bytes: tx_raw

--- a/v4-client-rs/client/src/noble/tokens.rs
+++ b/v4-client-rs/client/src/noble/tokens.rs
@@ -1,10 +1,32 @@
 use crate::indexer::{Denom, Tokenized};
 use anyhow::{anyhow as err, Error};
-use bigdecimal::{num_traits::ToPrimitive, BigDecimal};
+use bigdecimal::{num_traits::ToPrimitive, BigDecimal, One};
 use dydx_proto::cosmos_sdk_proto::cosmos::base::v1beta1::Coin as ProtoCoin;
 
 /// USDC Noble token.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct NobleUsdc(pub BigDecimal);
+
+impl NobleUsdc {
+    const QUANTUMS_ATOMIC_RESOLUTION: i64 = -6;
+
+    /// Create a micro USDC (1e-6) token from an integer.
+    pub fn from_quantums(quantums: impl Into<BigDecimal>) -> Self {
+        Self(quantums.into() / BigDecimal::new(One::one(), Self::QUANTUMS_ATOMIC_RESOLUTION))
+    }
+
+    /// Express a USDC token as an integer.
+    pub fn quantize(self) -> BigDecimal {
+        self.0 * BigDecimal::new(One::one(), Self::QUANTUMS_ATOMIC_RESOLUTION)
+    }
+
+    /// Express a USDC token as a u64.
+    pub fn quantize_as_u64(self) -> Result<u64, Error> {
+        self.quantize()
+            .to_u64()
+            .ok_or_else(|| err!("Failed converting USDC value to u64"))
+    }
+}
 
 impl<T> From<T> for NobleUsdc
 where
@@ -23,7 +45,8 @@ impl Tokenized for NobleUsdc {
     fn coin(&self) -> Result<ProtoCoin, Error> {
         Ok(ProtoCoin {
             amount: self
-                .0
+                .clone()
+                .quantize()
                 .to_u128()
                 .ok_or_else(|| err!("Failed converting Noble USDC value into amount"))?
                 .to_string(),

--- a/v4-client-rs/client/tests/mainnet.toml
+++ b/v4-client-rs/client/tests/mainnet.toml
@@ -5,5 +5,10 @@ chain_id = "dydx-mainnet-1"
 fee_denom = "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5"
 
 [indexer]
-http.endpoint = "https://indexer.dydx.trade/v4"
+http.endpoint = "https://indexer.dydx.trade"
 ws.endpoint = "wss://indexer.dydx.trade/v4/ws"
+
+[noble]
+endpoint = "http://noble-grpc.polkachu.com:21590"
+chain_id = "noble-1"
+fee_denom = "uusdc"


### PR DESCRIPTION
Reviews dYdX <-> Noble transfers,
- Fixes the setting of the sequence number, fee simulation flow;
- Adds support code for `NobleUsdc` quantization;
- Adds example mainnet configuration.

Given the added logistics of the transfer process (setting up IBC relayers, etc), this was tested manually on the mainnet.