### PR TITLE
chore: Bump crate version to 0.2.0

### DIFF
--- a/v4-client-rs/CHANGELOG.md
+++ b/v4-client-rs/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2025-03-05
+
+### 🚀 Features
+
+- Create market permissionless (#304)
+- *(config)* Implement Serialize trait for configuration structs (#314)
+- Permissioned keys (#322)
+
+### 🐛 Bug Fixes
+
+- *(noble)* DYdX<->Noble transfers seqnum, `NobleUsdc` ergonomics (#336)
+
 ## [0.1.1] - 2024-12-02
 
 ### 🚀 Features

--- a/v4-client-rs/Cargo.toml
+++ b/v4-client-rs/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "LicenseRef-dYdX-Custom"
 


### PR DESCRIPTION
Principal change is the permissioned keys / authenticators feature.