### PR TITLE
fix(authenticators): Nested `config` encoding, use base64

### DIFF
--- a/v4-client-rs/client/Cargo.toml
+++ b/v4-client-rs/client/Cargo.toml
@@ -24,6 +24,7 @@ telemetry = [
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+base64 = "0.22"
 bigdecimal.workspace = true
 bip32 = { version = "0.5", default-features = false, features = ["bip39", "alloc", "secp256k1"] }
 cosmrs = "0.21.1"


### PR DESCRIPTION
Fixes nested Authenticator AnyOf/AllOf `config` encoding to be array of bytes:
- implements manual `serde` serializer;
- use base64.