### PR TITLE
chore(deny): Ignore `paste` unmaintained advisory

### DIFF
--- a/v4-client-rs/deny.toml
+++ b/v4-client-rs/deny.toml
@@ -16,6 +16,9 @@ feature-depth = 1
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
+ignore = [
+    "RUSTSEC-2024-0436"  # https://rustsec.org/advisories/RUSTSEC-2024-0436
+]
 
 [licenses]
 allow = [


### PR DESCRIPTION
Ignore dep `paste` unmaintained advisory, required indirectly. Tree:
```
paste v1.0.15 (proc-macro)
└── flex-error v0.4.4
    ├── ibc-proto v0.51.1
    │   └── dydx v0.2.0 (/Users/v0/nm/repos/x/v4-client-rs/client)
    ├── tendermint v0.40.1
    │   └── cosmrs v0.21.1
    │       └── dydx v0.2.0 (/Users/v0/nm/repos/x/v4-client-rs/client)
    └── tendermint-proto v0.40.1
        ├── cosmos-sdk-proto v0.26.1
        │   ├── cosmrs v0.21.1 (*)
        │   ├── dydx-proto v0.2.0
        │   │   └── dydx v0.2.0 (/Users/v0/nm/repos/x/v4-client-rs/client)
        │   └── ibc-proto v0.51.1 (*)
        ├── ibc-proto v0.51.1 (*)
        └── tendermint v0.40.1 (*)
```