### PR TITLE
docs: rust client doc typos

### DIFF
--- a/v4-client-rs/client/src/indexer/types.rs
+++ b/v4-client-rs/client/src/indexer/types.rs
@@ -117,7 +117,7 @@ pub enum CandleResolution {
     D1,
 }
 
-/// Representatio of an arbitrary ID.
+/// Representation of an arbitrary ID.
 #[derive(Clone, Debug)]
 pub struct AnyId;
 

--- a/v4-client-rs/client/src/noble/config.rs
+++ b/v4-client-rs/client/src/noble/config.rs
@@ -15,7 +15,7 @@ pub struct NobleConfig {
     /// Fee [`Denom`].
     pub fee_denom: Denom,
     /// The sequence is a value that represents the number of transactions sent from an account.
-    /// Either the client manages it automatically via quering the network for the next
+    /// Either the client manages it automatically via querying the network for the next
     /// sequence number or it is a responsibility of a user.
     /// It is a [replay prevention](https://docs.cosmos.network/v0.47/learn/beginner/tx-lifecycle).
     #[serde(default = "default_manage_sequencing")]

--- a/v4-client-rs/client/src/node/config.rs
+++ b/v4-client-rs/client/src/node/config.rs
@@ -21,7 +21,7 @@ pub struct NodeConfig {
     /// Have NodeClient manage transaction sequence numbering.
     ///
     /// Long-term (stateful) orders require managing a sequence number for an account.
-    /// Either the client manages it automatically via quering the network for the next
+    /// Either the client manages it automatically via querying the network for the next
     /// sequence number or it is a responsibility of a user.
     /// It is a [replay prevention](https://docs.dydx.exchange/api_integration-trading/short_term_vs_stateful).
     #[serde(default = "default_manage_sequencing")]

--- a/v4-client-rs/client/src/node/fee.rs
+++ b/v4-client-rs/client/src/node/fee.rs
@@ -7,7 +7,7 @@ use bigdecimal::{
 };
 use cosmrs::{tx::Fee, Coin};
 
-/// Gas ajdustement value to avoid rejected transactions caused by gas understimation.
+/// Gas adjustment value to avoid rejected transactions caused by gas underestimation.
 const GAS_MULTIPLIER: f64 = 1.8;
 
 pub(crate) fn default() -> Fee {

--- a/v4-client-rs/client/src/node/order.rs
+++ b/v4-client-rs/client/src/node/order.rs
@@ -274,7 +274,7 @@ impl OrderBuilder {
 
     /// Set as Take Profit Market order.
     ///
-    /// The order enters in force if the price reaches `trigger_price` and converst to an ordinary market order,
+    /// The order enters in force if the price reaches `trigger_price` and converts to an ordinary market order,
     /// i.e. it is executed at the best available market price.
     pub fn take_profit_market(
         mut self,

--- a/v4-client-rs/client/src/node/sequencer.rs
+++ b/v4-client-rs/client/src/node/sequencer.rs
@@ -20,7 +20,7 @@ pub enum Nonce {
     /// A sequence number is incremental, associated with the number of transactions (short-term
     /// orders excluded) issued by an [`Account`](super::wallet::Account).
     Sequence(u64),
-    /// A valid timestamp nonce folows the rules:
+    /// A valid timestamp nonce follows the rules:
     /// 1. now - 30s ≤ timestamp ≤ now + 30s;
     /// 2. timestamp is strictly larger than any of the largest 20 timestamp nonces previously submitted in the account’s lifetime;
     /// 3. timestamp has never been used before.

--- a/v4-client-rs/client/src/node/types.rs
+++ b/v4-client-rs/client/src/node/types.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, Display};
 
 /// [Chain ID](https://docs.dydx.exchange/infrastructure_providers-network/network_constants#chain-id)
-/// serves as a unique chain identificator to prevent replay attacks.
+/// serves as a unique chain identifier to prevent replay attacks.
 ///
 /// See also [Cosmos ecosystem](https://cosmos.directory/).
 #[derive(Debug, Eq, PartialEq, Clone, Display, AsRefStr, Deserialize, Serialize)]


### PR DESCRIPTION
This PR fixes small typos in Rust docs