### PR TITLE
feat: add get_compliance_screen to rust client

### DIFF
--- a/v4-client-rs/client/examples/utility_endpoint.rs
+++ b/v4-client-rs/client/examples/utility_endpoint.rs
@@ -38,5 +38,8 @@ async fn main() -> Result<()> {
     let screen = indexer.utility().get_screen(address).await?;
     tracing::info!("Screen for address {address}: {screen:?}");
 
+    let compliance_screen = indexer.utility().get_compliance_screen(address).await?;
+    tracing::info!("Compliance screen for address {address}: {compliance_screen:?}");
+
     Ok(())
 }

--- a/v4-client-rs/client/src/indexer/rest/client/utility.rs
+++ b/v4-client-rs/client/src/indexer/rest/client/utility.rs
@@ -72,7 +72,10 @@ impl<'a> Utility<'a> {
     /// Screens an address to determine if it is restricted.
     ///
     /// [Reference](https://docs.dydx.exchange/api_integration-indexer/indexer_api#compliance-screen).
-    pub async fn get_compliance_screen(&self, address: &Address) -> Result<ComplianceV2Response, Error> {
+    pub async fn get_compliance_screen(
+        &self,
+        address: &Address,
+    ) -> Result<ComplianceV2Response, Error> {
         let rest = &self.rest;
         const URI: &str = "/v4/compliance/screen";
         let url = format!("{}{URI}/{address}", rest.config.endpoint);

--- a/v4-client-rs/client/src/indexer/rest/client/utility.rs
+++ b/v4-client-rs/client/src/indexer/rest/client/utility.rs
@@ -68,4 +68,22 @@ impl<'a> Utility<'a> {
             .await?;
         Ok(resp)
     }
+
+    /// Screens an address to determine if it is restricted.
+    ///
+    /// [Reference](https://docs.dydx.exchange/api_integration-indexer/indexer_api#compliance-screen).
+    pub async fn get_compliance_screen(&self, address: &Address) -> Result<ComplianceV2Response, Error> {
+        let rest = &self.rest;
+        const URI: &str = "/v4/compliance/screen";
+        let url = format!("{}{URI}/{address}", rest.config.endpoint);
+        let resp = rest
+            .client
+            .get(url)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(resp)
+    }
 }

--- a/v4-client-rs/client/src/indexer/rest/types.rs
+++ b/v4-client-rs/client/src/indexer/rest/types.rs
@@ -117,6 +117,52 @@ pub struct ComplianceResponse {
     pub reason: Option<String>,
 }
 
+/// Compliance status.
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ComplianceStatus {
+    /// Compliant.
+    Compliant,
+    /// First strike close only.
+    FirstStrikeCloseOnly,
+    /// First strike.
+    FirstStrike,
+    /// Close only.
+    CloseOnly,
+    /// Blocked.
+    Blocked,
+}
+
+/// Compliance reason.
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ComplianceReason {
+    /// Manual.
+    Manual,
+    /// US geo.
+    UsGeo,
+    /// CA geo.
+    CaGeo,
+    /// GB geo.
+    GbGeo,
+    /// Sanctioned geo.
+    SanctionedGeo,
+    /// Compliance provider.
+    ComplianceProvider,
+}
+
+/// Compliance response v2.
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ComplianceV2Response {
+    /// Status.
+    pub status: ComplianceStatus,
+    /// Reason.
+    pub reason: Option<ComplianceReason>,
+    /// Updated at.
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
 /// Address response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/v4-client-rs/client/tests/test_indexer_rest.rs
+++ b/v4-client-rs/client/tests/test_indexer_rest.rs
@@ -102,7 +102,10 @@ async fn test_indexer_utility_get_screen() -> Result<()> {
 #[tokio::test]
 async fn test_indexer_utility_get_compliance_screen() -> Result<()> {
     let env = TestEnv::testnet().await?;
-    env.indexer.utility().get_compliance_screen(&env.address).await?;
+    env.indexer
+        .utility()
+        .get_compliance_screen(&env.address)
+        .await?;
     Ok(())
 }
 

--- a/v4-client-rs/client/tests/test_indexer_rest.rs
+++ b/v4-client-rs/client/tests/test_indexer_rest.rs
@@ -100,6 +100,13 @@ async fn test_indexer_utility_get_screen() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_indexer_utility_get_compliance_screen() -> Result<()> {
+    let env = TestEnv::testnet().await?;
+    env.indexer.utility().get_compliance_screen(&env.address).await?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_indexer_account_get_subaccounts() -> Result<()> {
     let env = TestEnv::testnet().await?;
     env.indexer.accounts().get_subaccounts(&env.address).await?;


### PR DESCRIPTION
This PR adds missing `get_compliance_screen` method to Rust client, together with it's test 