### PR TITLE
fix: remove ids from PnlTicksResponseObject in Rust client

### DIFF
--- a/v4-client-rs/client/src/indexer/rest/types.rs
+++ b/v4-client-rs/client/src/indexer/rest/types.rs
@@ -250,10 +250,6 @@ pub struct HistoricalPnlResponse {
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PnlTicksResponseObject {
-    /// Report id.
-    pub id: PnlTickId,
-    /// Subaccount id.
-    pub subaccount_id: SubaccountId,
     /// Block height.
     pub block_height: Height,
     /// Time (UTC).


### PR DESCRIPTION
This PR fixes Rust tests