### PR TITLE
chore: update indexer types with latest protocol changes

### DIFF
--- a/v4-client-rs/Cargo.toml
+++ b/v4-client-rs/Cargo.toml
@@ -17,4 +17,4 @@ derive_more = { version = "2", features = ["full"] }
 log = "0.4"
 thiserror = "2"
 tokio = { version = "1.43", features = ["fs", "rt-multi-thread"] }
-dydx-proto = "0.2.0"
+dydx-proto = "0.3.0"

--- a/v4-client-rs/client/examples/validator_post.rs
+++ b/v4-client-rs/client/examples/validator_post.rs
@@ -67,6 +67,8 @@ async fn main() -> Result<()> {
             condition_type: ConditionType::Unspecified.into(),
             conditional_order_trigger_subticks: 0u64,
             good_til_oneof: Some(GoodTilOneof::GoodTilBlock(til_height)),
+            builder_code_parameters: None,
+            twap_parameters: None,
         };
 
         let tx_hash = placer.client.place_order(&mut account, order).await?;

--- a/v4-client-rs/client/src/indexer/rest/client/accounts.rs
+++ b/v4-client-rs/client/src/indexer/rest/client/accounts.rs
@@ -243,7 +243,7 @@ impl<'a> Accounts<'a> {
         &self,
         subaccount: &ParentSubaccount,
         opts: Option<GetTransfersOpts>,
-    ) -> Result<Vec<TransferResponseObject>, Error> {
+    ) -> Result<Vec<ParentSubaccountTransferResponseObject>, Error> {
         let rest = &self.rest;
         const URI: &str = "/v4/transfers";
         let url = format!("{}{URI}/parentSubaccountNumber", rest.config.endpoint);
@@ -260,7 +260,7 @@ impl<'a> Accounts<'a> {
             .send()
             .await?
             .error_for_status()?
-            .json::<TransferResponse>()
+            .json::<ParentSubaccountTransferResponse>()
             .await?
             .transfers;
         Ok(transfers)

--- a/v4-client-rs/client/src/indexer/rest/client/mod.rs
+++ b/v4-client-rs/client/src/indexer/rest/client/mod.rs
@@ -19,6 +19,7 @@ use vaults::Vaults;
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 struct Query<'t> {
     address: &'t Address,
     subaccount_number: &'t SubaccountNumber,
@@ -26,6 +27,7 @@ struct Query<'t> {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 struct QueryParent<'t> {
     address: &'t Address,
     parent_subaccount_number: &'t ParentSubaccountNumber,
@@ -33,6 +35,7 @@ struct QueryParent<'t> {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 struct GetTransfersBetweenQuery<'t> {
     source_address: &'t Address,
     source_subaccount_number: &'t SubaccountNumber,

--- a/v4-client-rs/client/src/indexer/rest/types.rs
+++ b/v4-client-rs/client/src/indexer/rest/types.rs
@@ -9,6 +9,7 @@ use crate::indexer::types::*;
 /// REST Indexer response error.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct ResponseError {
     /// Errors.
     pub errors: Vec<ErrorMsg>,
@@ -17,6 +18,7 @@ pub struct ResponseError {
 /// REST Indexer error message.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct ErrorMsg {
     /// Message.
     pub msg: String,
@@ -73,6 +75,7 @@ pub enum SparklineTimePeriod {
 /// Fundings response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct HistoricalFundingResponse {
     /// List of fundings
     pub historical_funding: Vec<HistoricalFundingResponseObject>,
@@ -81,6 +84,7 @@ pub struct HistoricalFundingResponse {
 /// Funding response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct HistoricalFundingResponseObject {
     /// Market ticker.
     pub ticker: Ticker,
@@ -100,6 +104,7 @@ pub type SparklineResponseObject = HashMap<Ticker, Vec<BigDecimal>>;
 /// Indexer server time.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct TimeResponse {
     /// Time (UTC).
     pub iso: DateTime<Utc>,
@@ -110,6 +115,7 @@ pub struct TimeResponse {
 /// Compliance response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct ComplianceResponse {
     /// Whether the address is restricted.
     pub restricted: bool,
@@ -154,6 +160,7 @@ pub enum ComplianceReason {
 /// Compliance response v2.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct ComplianceV2Response {
     /// Status.
     pub status: ComplianceStatus,
@@ -166,6 +173,7 @@ pub struct ComplianceV2Response {
 /// Address response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct AddressResponse {
     /// List of all subaccounts.
     pub subaccounts: Vec<SubaccountResponseObject>,
@@ -176,6 +184,7 @@ pub struct AddressResponse {
 /// Subaccount response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct SubaccountResponse {
     /// Subaccount.
     pub subaccount: SubaccountResponseObject,
@@ -184,6 +193,7 @@ pub struct SubaccountResponse {
 /// Parent subaccount response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct ParentSubaccountResponse {
     /// Subaccount.
     pub subaccount: ParentSubaccountResponseObject,
@@ -192,6 +202,7 @@ pub struct ParentSubaccountResponse {
 /// Asset positions response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct AssetPositionResponse {
     /// Asset positions.
     pub positions: Vec<AssetPositionResponseObject>,
@@ -200,6 +211,7 @@ pub struct AssetPositionResponse {
 /// Perpetual positions response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct PerpetualPositionResponse {
     /// Perpetual positions.
     pub positions: Vec<PerpetualPositionResponseObject>,
@@ -208,6 +220,7 @@ pub struct PerpetualPositionResponse {
 /// Pagination request.
 #[derive(Serialize, Default, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct PaginationRequest {
     /// Limit.
     pub limit: Option<u32>,
@@ -218,6 +231,7 @@ pub struct PaginationRequest {
 /// Affiliate metadata response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct AffiliateMetadataResponse {
     /// Referral code.
     pub referral_code: String,
@@ -230,6 +244,7 @@ pub struct AffiliateMetadataResponse {
 /// Affiliate address response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct AffiliateAddressResponse {
     /// Address.
     pub address: Address,
@@ -238,6 +253,7 @@ pub struct AffiliateAddressResponse {
 /// Affiliate snapshot response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct AffiliateSnapshotResponse {
     /// Affiliate list.
     pub affiliate_list: Vec<AffiliateSnapshotResponseObject>,
@@ -250,6 +266,7 @@ pub struct AffiliateSnapshotResponse {
 /// Affiliate snapshot response object.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct AffiliateSnapshotResponseObject {
     /// Affiliate address.
     pub affiliate_address: Address,
@@ -278,6 +295,7 @@ pub struct AffiliateSnapshotResponseObject {
 /// Affiliate total volume response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct AffiliateTotalVolumeResponse {
     /// Total volume.
     pub total_volume: Option<BigDecimal>,
@@ -286,6 +304,7 @@ pub struct AffiliateTotalVolumeResponse {
 /// Pagination response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct PaginationResponse {
     /// Page size.
     pub page_size: Option<u32>,
@@ -298,6 +317,7 @@ pub struct PaginationResponse {
 /// Transfers response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct TransferResponse {
     /// List of transfers.
     pub transfers: Vec<TransferResponseObject>,
@@ -306,9 +326,19 @@ pub struct TransferResponse {
     pub pagination: PaginationResponse,
 }
 
+/// Parent subaccount transfer response.
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct ParentSubaccountTransferResponse {
+    /// List of transfers.
+    pub transfers: Vec<ParentSubaccountTransferResponseObject>,
+}
+
 /// Trader search response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct TraderSearchResponse {
     /// Result.
     pub result: Option<TraderSearchResponseObject>,
@@ -317,6 +347,7 @@ pub struct TraderSearchResponse {
 /// Trader search response object.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct TraderSearchResponseObject {
     /// Address.
     pub address: Address,
@@ -331,6 +362,7 @@ pub struct TraderSearchResponseObject {
 /// Transfer between response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct TransferBetweenResponse {
     /// List of transfers.
     pub transfers_subset: Vec<TransferResponseObject>,
@@ -344,6 +376,7 @@ pub struct TransferBetweenResponse {
 /// Funding payment response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct FundingPaymentResponse {
     /// List of funding payments.
     pub funding_payments: Vec<FundingPaymentResponseObject>,
@@ -355,6 +388,7 @@ pub struct FundingPaymentResponse {
 /// Funding payment response object.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct FundingPaymentResponseObject {
     /// Time (UTC).
     pub created_at: DateTime<Utc>,
@@ -391,28 +425,56 @@ pub enum FundingOrderSide {
 }
 
 /// Transfer response.
+/// T is the type of the sender and recipient.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct TransferResponseObject {
     /// Transfer id.
     pub id: TransferId,
-    /// Time (UTC).
-    pub created_at: DateTime<Utc>,
-    /// Block height.
-    pub created_at_height: Height,
     /// Sender of transfer.
     pub sender: Account,
     /// Recipient of transfer.
     pub recipient: Account,
     /// Size of transfer.
     pub size: BigDecimal,
+    /// Time (UTC).
+    pub created_at: DateTime<Utc>,
+    /// Block height.
+    pub created_at_height: Height,
     /// Token symbol.
     pub symbol: Symbol,
-    /// Transfer transaction hash.
-    pub transaction_hash: String,
     /// Transfer type.
     #[serde(rename = "type")]
     pub transfer_type: TransferType,
+    /// Transfer transaction hash.
+    pub transaction_hash: String,
+}
+
+/// Parent subaccount transfer response object.
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct ParentSubaccountTransferResponseObject {
+    /// Transfer id.
+    pub id: TransferId,
+    /// Sender of transfer.
+    pub sender: AccountWithParentSubaccountNumber,
+    /// Recipient of transfer.
+    pub recipient: AccountWithParentSubaccountNumber,
+    /// Size of transfer.
+    pub size: BigDecimal,
+    /// Time (UTC).
+    pub created_at: DateTime<Utc>,
+    /// Block height.
+    pub created_at_height: Height,
+    /// Token symbol.
+    pub symbol: Symbol,
+    /// Transfer type.
+    #[serde(rename = "type")]
+    pub transfer_type: TransferType,
+    /// Transfer transaction hash.
+    pub transaction_hash: String,
 }
 
 /// Orders list response.
@@ -421,6 +483,7 @@ pub type ListOrdersResponse = Vec<OrderResponseObject>;
 /// Fills response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct FillResponse {
     /// List of fills.
     pub fills: Vec<FillResponseObject>,
@@ -429,41 +492,49 @@ pub struct FillResponse {
 /// Fill response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct FillResponseObject {
     /// Fill id.
     pub id: FillId,
     /// Side (buy/sell).
     pub side: OrderSide,
-    /// Size.
-    pub size: BigDecimal,
-    /// Fee.
-    pub fee: BigDecimal,
+    /// Liquidity.
+    pub liquidity: Liquidity,
     /// Fill type.
     #[serde(rename = "type")]
     pub fill_type: FillType,
-    /// Liquidity.
-    pub liquidity: Liquidity,
     /// Market ticker.
     pub market: Ticker,
     /// Market type.
     pub market_type: MarketType,
     /// Price.
     pub price: Price,
-    /// Subaccount number.
-    pub subaccount_number: SubaccountNumber,
-    /// Block height.
-    pub created_at_height: Height,
+    /// Size.
+    pub size: BigDecimal,
+    /// Fee.
+    pub fee: BigDecimal,
+    /// Affiliate rev share.
+    pub affiliate_rev_share: BigDecimal,
     /// Time (UTC).
     pub created_at: DateTime<Utc>,
-    /// Client metadata.
-    pub client_metadata: Option<ClientMetadata>,
+    /// Block height.
+    pub created_at_height: Height,
     /// Order id.
     pub order_id: Option<OrderId>,
+    /// Client metadata.
+    pub client_metadata: Option<ClientMetadata>,
+    /// Subaccount number.
+    pub subaccount_number: SubaccountNumber,
+    /// Builder fee.
+    pub builder_fee: Option<BigDecimal>,
+    /// Builder address.
+    pub builder_address: Option<Address>,
 }
 
 /// Profit and loss reports.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct HistoricalPnlResponse {
     /// List of PnL reports.
     pub historical_pnl: Vec<PnlTicksResponseObject>,
@@ -472,6 +543,7 @@ pub struct HistoricalPnlResponse {
 /// Profit and loss report.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct PnlTicksResponseObject {
     /// Block height.
     pub block_height: Height,
@@ -490,6 +562,7 @@ pub struct PnlTicksResponseObject {
 /// Trading rewards reports.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct HistoricalBlockTradingRewardsResponse {
     /// List of reports.
     pub rewards: Vec<HistoricalBlockTradingReward>,
@@ -498,6 +571,7 @@ pub struct HistoricalBlockTradingRewardsResponse {
 /// Trading rewards report.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct HistoricalBlockTradingReward {
     /// Trading reward amount.
     pub trading_reward: BigDecimal,
@@ -510,6 +584,7 @@ pub struct HistoricalBlockTradingReward {
 /// Trading rewards aggregation reports.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct HistoricalTradingRewardAggregationsResponse {
     /// List of reports.
     pub rewards: Vec<HistoricalTradingRewardAggregation>,
@@ -518,6 +593,7 @@ pub struct HistoricalTradingRewardAggregationsResponse {
 /// Trading rewards aggregation report.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct HistoricalTradingRewardAggregation {
     /// Trading reward amount.
     pub trading_reward: BigDecimal,
@@ -536,6 +612,7 @@ pub struct HistoricalTradingRewardAggregation {
 /// MegaVault Profit and loss reports.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct MegaVaultHistoricalPnlResponse {
     /// List of PnL reports.
     pub megavault_pnl: Vec<PnlTicksResponseObject>,
@@ -544,6 +621,7 @@ pub struct MegaVaultHistoricalPnlResponse {
 /// MegaVault Profit and loss reports.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct MegaVaultPositionResponse {
     /// List MegaVault positions.
     pub positions: Vec<VaultPosition>,
@@ -552,6 +630,7 @@ pub struct MegaVaultPositionResponse {
 /// Vaults profit and loss reports.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct VaultsHistoricalPnLResponse {
     /// List of PnL reports.
     pub vaults_pnl: Vec<VaultHistoricalPnl>,
@@ -560,6 +639,7 @@ pub struct VaultsHistoricalPnLResponse {
 /// Vault Profit and loss reports.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct VaultHistoricalPnl {
     /// Associated ticker.
     pub ticker: String,
@@ -570,6 +650,7 @@ pub struct VaultHistoricalPnl {
 /// Vault position.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct VaultPosition {
     /// Associated ticker.
     pub ticker: String,

--- a/v4-client-rs/client/src/indexer/sock/messages.rs
+++ b/v4-client-rs/client/src/indexer/sock/messages.rs
@@ -473,6 +473,7 @@ pub struct SubaccountsInitialMessage {
 /// Subaccount.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct SubaccountsInitialMessageContents {
     /// Subaccount.
     pub subaccount: SubaccountMessageObject,
@@ -498,6 +499,7 @@ pub struct ParentSubaccountsInitialMessage {
 /// Parent subaccount.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct ParentSubaccountsInitialMessageContents {
     /// Subaccount.
     pub subaccount: ParentSubaccountMessageObject,
@@ -619,6 +621,7 @@ generate_contents_deserialize_function!(
 /// Subaccount update contents.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct SubaccountUpdateMessageContents {
     /// Perpetual position updates on the subaccount.
     pub perpetual_positions: Option<Vec<PerpetualPositionSubaccountMessageContents>>,
@@ -639,6 +642,7 @@ pub struct SubaccountUpdateMessageContents {
 /// Perpetual position on subaccount.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct PerpetualPositionSubaccountMessageContents {
     /// Address.
     pub address: Address,
@@ -675,6 +679,7 @@ pub struct PerpetualPositionSubaccountMessageContents {
 /// Asset position per subaccount.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct AssetPositionSubaccountMessageContents {
     /// Address.
     pub address: Address,
@@ -695,6 +700,7 @@ pub struct AssetPositionSubaccountMessageContents {
 /// Order per subaccount.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct OrderSubaccountMessageContents {
     /// Id.
     pub id: String,
@@ -750,6 +756,7 @@ pub struct OrderSubaccountMessageContents {
 /// Fill per subaccount.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct FillSubaccountMessageContents {
     /// Fill id.
     pub id: FillId,
@@ -789,6 +796,7 @@ pub struct FillSubaccountMessageContents {
 /// Transfer per subaccount.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct TransferSubaccountMessageContents {
     /// Sender.
     pub sender: Account,
@@ -812,6 +820,7 @@ pub struct TransferSubaccountMessageContents {
 /// Trading reward.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct TradingRewardSubaccountMessageContents {
     /// Trading reward.
     pub trading_reward: BigDecimal,
@@ -840,6 +849,7 @@ pub struct ParentSubaccountsUpdateMessage {
 /// Subaccount update contents.
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct ParentSubaccountUpdateMessageContents {
     /// Perpetual position updates on the subaccount.
     pub perpetual_positions: Option<Vec<PerpetualPositionSubaccountMessageContents>>,
@@ -944,6 +954,7 @@ generate_contents_deserialize_function!(deserialize_trades_contents, TradesUpdat
 /// Trades updates.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct TradesUpdateMessageContents {
     /// Updates.
     pub trades: Vec<TradeUpdate>,
@@ -952,6 +963,7 @@ pub struct TradesUpdateMessageContents {
 /// Trade update.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct TradeUpdate {
     /// Unique id of the trade, which is the taker fill id.
     pub id: TradeId,
@@ -986,6 +998,7 @@ generate_contents_deserialize_function!(deserialize_markets_contents, MarketsUpd
 /// Markets update.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct MarketsUpdateMessageContents {
     /// Trading.
     pub trading: Option<HashMap<Ticker, TradingPerpetualMarket>>,
@@ -996,6 +1009,7 @@ pub struct MarketsUpdateMessageContents {
 /// Perpetual market info.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct TradingPerpetualMarket {
     /// Atomic resolution
     pub atomic_resolution: Option<i32>,
@@ -1049,6 +1063,7 @@ pub struct TradingPerpetualMarket {
 /// Oracle price for market.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct OraclePriceMarket {
     /// Oracle price.
     pub oracle_price: Price,
@@ -1098,6 +1113,7 @@ generate_contents_deserialize_function!(
 /// Block height update message contents.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct BlockHeightUpdateMessageContents {
     /// Block height.
     pub block_height: Height,

--- a/v4-client-rs/client/src/indexer/types.rs
+++ b/v4-client-rs/client/src/indexer/types.rs
@@ -14,12 +14,26 @@ use std::{fmt, str::FromStr};
 
 // Shared types used by REST API, WS
 
+/// A trader's account with a parent subaccount number.
+#[derive(Deserialize, Debug, Clone, Eq, Hash, PartialOrd, Ord, PartialEq)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct AccountWithParentSubaccountNumber {
+    /// Address.
+    pub address: Address,
+    /// Parent subaccount number.
+    pub parent_subaccount_number: Option<ParentSubaccountNumber>,
+}
+
 /// A trader's account.
 #[derive(Deserialize, Debug, Clone, Eq, Hash, PartialOrd, Ord, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct Account {
     /// Address.
     pub address: Address,
+    /// Parent subaccount number.
+    pub subaccount_number: Option<SubaccountNumber>,
 }
 
 /// [Address](https://dydx.exchange/crypto-learning/what-is-a-wallet-address).
@@ -406,6 +420,7 @@ pub enum OrderType {
 /// Subaccount.
 #[derive(Deserialize, Debug, Clone, Eq, Hash, PartialOrd, Ord, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct Subaccount {
     /// Address.
     pub address: Address,
@@ -472,7 +487,7 @@ impl<'de> Deserialize<'de> for SubaccountNumber {
                 value
                     .parse::<u32>()
                     .map(SubaccountNumber)
-                    .map_err(|_| E::custom(format!("invalid u32 in string: {}", value)))
+                    .map_err(|_| E::custom(format!("invalid u32 in string: {value}")))
             }
         }
 
@@ -530,6 +545,7 @@ impl From<ParentSubaccountNumber> for SubaccountNumber {
 /// See also [how isolated positions are handled in dYdX](https://docs.dydx.exchange/api_integration-guides/how_to_isolated#mapping-of-isolated-positions-to-subaccounts).
 #[derive(Deserialize, Debug, Clone, Eq, Hash, PartialOrd, Ord, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct ParentSubaccount {
     /// Address.
     pub address: Address,
@@ -715,6 +731,7 @@ impl TryFrom<Denom> for CosmosDenom {
 /// Parent subaccount response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct ParentSubaccountResponseObject {
     /// Address.
     pub address: Address,
@@ -724,8 +741,6 @@ pub struct ParentSubaccountResponseObject {
     pub equity: BigDecimal,
     /// Free collateral.
     pub free_collateral: BigDecimal,
-    /// Is margin enabled?
-    pub margin_enabled: Option<bool>,
     /// Associated child subaccounts.
     pub child_subaccounts: Vec<SubaccountResponseObject>,
 }
@@ -733,6 +748,7 @@ pub struct ParentSubaccountResponseObject {
 /// Subaccount response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct SubaccountResponseObject {
     /// Address.
     pub address: Address,
@@ -742,17 +758,22 @@ pub struct SubaccountResponseObject {
     pub equity: BigDecimal,
     /// Free collateral.
     pub free_collateral: BigDecimal,
-    /// Is margin enabled?
-    pub margin_enabled: Option<bool>,
-    /// Asset positions.
-    pub asset_positions: AssetPositionsMap,
     /// Opened perpetual positions.
     pub open_perpetual_positions: PerpetualPositionsMap,
+    /// Asset positions.
+    pub asset_positions: AssetPositionsMap,
+    /// Is margin enabled?
+    pub margin_enabled: bool,
+    /// Updated at height.
+    pub updated_at_height: Height,
+    /// Latest processed block height.
+    pub latest_processed_block_height: Height,
 }
 
 /// Asset position response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct AssetPositionResponseObject {
     /// Token symbol.
     pub symbol: Symbol,
@@ -769,6 +790,7 @@ pub struct AssetPositionResponseObject {
 /// Perpetual position response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct PerpetualPositionResponseObject {
     /// Market ticker.
     pub market: Ticker,
@@ -887,6 +909,7 @@ impl FromStr for Quantity {
 /// Orderbook price level.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct OrderbookResponsePriceLevel {
     /// Price.
     pub price: Price,
@@ -897,6 +920,7 @@ pub struct OrderbookResponsePriceLevel {
 /// Orderbook response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct OrderBookResponseObject {
     /// Bids.
     pub bids: Vec<OrderbookResponsePriceLevel>,
@@ -907,6 +931,7 @@ pub struct OrderBookResponseObject {
 /// Order response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct OrderResponseObject {
     /// Client id.
     pub client_id: ClientId,
@@ -953,11 +978,18 @@ pub struct OrderResponseObject {
     pub updated_at: Option<DateTime<Utc>>,
     /// Block height.
     pub updated_at_height: Option<Height>,
+    /// Trigger price.
+    pub trigger_price: Option<Price>,
+    /// Builder fee.
+    pub builder_fee: Option<BigDecimal>,
+    /// Fee ppm.
+    pub fee_ppm: Option<BigDecimal>,
 }
 
 /// Trade response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct TradeResponse {
     /// Trades.
     pub trades: Vec<TradeResponseObject>,
@@ -966,6 +998,7 @@ pub struct TradeResponse {
 /// Trade.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct TradeResponseObject {
     /// Trade id.
     pub id: TradeId,
@@ -987,6 +1020,7 @@ pub struct TradeResponseObject {
 /// Perpetual markets.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct PerpetualMarketResponse {
     /// Perpetual markets.
     pub markets: HashMap<Ticker, PerpetualMarket>,
@@ -995,52 +1029,56 @@ pub struct PerpetualMarketResponse {
 /// Perpetual market.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct PerpetualMarket {
-    /// Atomic resolution
-    pub atomic_resolution: i32,
-    /// Base open interest.
-    pub base_open_interest: BigDecimal,
     /// Clob pair id.
     pub clob_pair_id: ClobPairId,
-    /// Initial margin fraction.
-    pub initial_margin_fraction: BigDecimal,
-    /// Maintenance margin fraction.
-    pub maintenance_margin_fraction: BigDecimal,
-    /// Market type.
-    pub market_type: PerpetualMarketType,
-    /// Next funding rate.
-    pub next_funding_rate: BigDecimal,
-    /// Open interest.
-    pub open_interest: BigDecimal,
-    /// Open interest lower capitalization.
-    pub open_interest_lower_cap: Option<BigDecimal>,
-    /// Open interest upper capitalization.
-    pub open_interest_upper_cap: Option<BigDecimal>,
+    /// Market ticker.
+    pub ticker: Ticker,
+    /// Market status
+    pub status: PerpetualMarketStatus,
     /// Oracle price.
     pub oracle_price: Option<Price>,
     /// 24-h price change.
     #[serde(rename = "priceChange24H")]
     pub price_change_24h: BigDecimal,
-    /// Quantum conversion exponent.
-    pub quantum_conversion_exponent: i32,
-    /// Market status
-    pub status: PerpetualMarketStatus,
-    /// Step base quantums.
-    pub step_base_quantums: u64,
-    /// Step size.
-    pub step_size: BigDecimal,
-    /// Subticks per tick.
-    pub subticks_per_tick: u32,
-    /// Tick size.
-    pub tick_size: BigDecimal,
-    /// Market ticker.
-    pub ticker: Ticker,
-    /// 24-h number of trades.
-    #[serde(rename = "trades24H")]
-    pub trades_24h: u64,
     /// 24-h volume.
     #[serde(rename = "volume24H")]
     pub volume_24h: Quantity,
+    /// 24-h number of trades.
+    #[serde(rename = "trades24H")]
+    pub trades_24h: u64,
+    /// Next funding rate.
+    pub next_funding_rate: BigDecimal,
+    /// Initial margin fraction.
+    pub initial_margin_fraction: BigDecimal,
+    /// Maintenance margin fraction.
+    pub maintenance_margin_fraction: BigDecimal,
+    /// Open interest.
+    pub open_interest: BigDecimal,
+    /// Atomic resolution
+    pub atomic_resolution: i32,
+    /// Quantum conversion exponent.
+    pub quantum_conversion_exponent: i32,
+    /// Tick size.
+    pub tick_size: BigDecimal,
+    /// Step size.
+    pub step_size: BigDecimal,
+    /// Step base quantums.
+    pub step_base_quantums: u64,
+    /// Subticks per tick.
+    pub subticks_per_tick: u32,
+    /// Market type.
+    pub market_type: PerpetualMarketType,
+    /// Open interest lower capitalization.
+    pub open_interest_lower_cap: Option<BigDecimal>,
+    /// Open interest upper capitalization.
+    pub open_interest_upper_cap: Option<BigDecimal>,
+    /// Base open interest.
+    pub base_open_interest: BigDecimal,
+    /// Default funding rate 1H.
+    #[serde(rename = "defaultFundingRate1H")]
+    pub default_funding_rate_1h: Option<BigDecimal>,
 }
 
 impl PerpetualMarket {
@@ -1062,6 +1100,7 @@ impl PerpetualMarket {
 /// Candle response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct CandleResponse {
     /// List of candles.
     pub candles: Vec<CandleResponseObject>,
@@ -1070,34 +1109,40 @@ pub struct CandleResponse {
 /// Candle response.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct CandleResponseObject {
-    /// Market ticker.
-    pub ticker: Ticker,
-    /// Number of trades.
-    pub trades: u64,
     /// Time(UTC).
     pub started_at: DateTime<Utc>,
-    /// Base token volume.
-    pub base_token_volume: Quantity,
-    /// Token price at open.
-    pub open: Price,
+    /// Market ticker.
+    pub ticker: Ticker,
+    /// Candle resolution.
+    pub resolution: CandleResolution,
     /// Low price volume.
     pub low: Price,
     /// High price volume.
     pub high: Price,
+    /// Token price at open.
+    pub open: Price,
     /// Token price at close.
     pub close: Price,
-    /// Candle resolution.
-    pub resolution: CandleResolution,
+    /// Base token volume.
+    pub base_token_volume: Quantity,
     /// USD volume.
     pub usd_volume: Quantity,
+    /// Number of trades.
+    pub trades: u64,
     /// Starting open interest.
     pub starting_open_interest: BigDecimal,
+    /// Orderbook mid price open.
+    pub orderbook_mid_price_open: Option<Price>,
+    /// Orderbook mid price close.
+    pub orderbook_mid_price_close: Option<Price>,
 }
 
 /// Block height parsed by Indexer.
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct HeightResponse {
     /// Block height.
     pub height: Height,

--- a/v4-client-rs/client/src/node/client/authenticators.rs
+++ b/v4-client-rs/client/src/node/client/authenticators.rs
@@ -193,7 +193,7 @@ impl serde::Serialize for Authenticator {
             | Authenticator::ClobPairIdFilter(string) => string.clone().into_bytes(),
             Authenticator::AnyOf(auths) | Authenticator::AllOf(auths) => {
                 serde_json::to_string(auths)
-                    .map_err(|e| ser::Error::custom(format!("JSON serialization error: {}", e)))?
+                    .map_err(|e| ser::Error::custom(format!("JSON serialization error: {e}")))?
                     .into_bytes()
             }
         };

--- a/v4-client-rs/client/tests/test_node.rs
+++ b/v4-client-rs/client/tests/test_node.rs
@@ -83,6 +83,8 @@ async fn test_node_order_generator() -> Result<(), Error> {
         condition_type: ConditionType::Unspecified.into(),
         conditional_order_trigger_subticks: 0u64,
         good_til_oneof: Some(order::GoodTilOneof::GoodTilBlock(until_height.0)),
+        builder_code_parameters: None,
+        twap_parameters: None,
     };
 
     // Conditional stop market order
@@ -116,6 +118,8 @@ async fn test_node_order_generator() -> Result<(), Error> {
         good_til_oneof: Some(order::GoodTilOneof::GoodTilBlockTime(
             until_time.timestamp().try_into().unwrap(),
         )),
+        builder_code_parameters: None,
+        twap_parameters: None,
     };
 
     // Long-term limit order
@@ -147,6 +151,8 @@ async fn test_node_order_generator() -> Result<(), Error> {
         good_til_oneof: Some(order::GoodTilOneof::GoodTilBlockTime(
             until_time.timestamp().try_into().unwrap(),
         )),
+        builder_code_parameters: None,
+        twap_parameters: None,
     };
 
     assert_eq!(order_ms.1, order_ms_r);


### PR DESCRIPTION
This PR:
- Updates `dydx-proto` version.
- Introduces `#[serde(deny_unknown_fields)]` to not miss any fields from return types.
- Adds several missed return types.
- Reorders some of the struct fields to align with the indexer implementation.
- Has some minor fixes for new clippy version