### PR TITLE
fix: url mapping of getParentSubaccount

### DIFF
--- a/v4-client-js/src/clients/modules/account.ts
+++ b/v4-client-js/src/clients/modules/account.ts
@@ -26,7 +26,7 @@ export default class AccountClient extends RestClient {
   }
 
   async getParentSubaccount(address: string, parentSubaccountNumber: number): Promise<Data> {
-    const uri = `/v4/addresses/${address}/subaccountNumber/${parentSubaccountNumber}`;
+    const uri = `/v4/addresses/${address}/parentSubaccountNumber/${parentSubaccountNumber}`;
     return this.get(uri);
   }
 


### PR DESCRIPTION
Reference to the PR this one is created in place of [here](https://github.com/dydxprotocol/v4-clients/pull/389)