### PR TITLE
fix: fix `permissoned keys` example

### DIFF
--- a/v4-client-js/examples/constants.ts
+++ b/v4-client-js/examples/constants.ts
@@ -17,6 +17,9 @@ export const DYDX_LOCAL_MNEMONIC =
 
 export const DYDX_TEST_MNEMONIC_2 = 'movie yard still copper exile wear brisk chest ride dizzy novel future menu finish radar lunar claim hub middle force turtle mouse frequent embark';
 
+// dydx1fxu2ndxwju2evh28js0cflkxn5wxzvlhw4gec5
+export const DYDX_TEST_MNEMONIC_3 = 'crane poverty boil edit response weasel quick almost fringe able upon benefit boil boat narrow innocent enter cradle tongue toward luggage awful mention column';
+
 export const MARKET_BTC_USD: string = 'BTC-USD';
 export const PERPETUAL_PAIR_BTC_USD: number = 0;
 

--- a/v4-client-js/examples/permissioned_keys_example.ts
+++ b/v4-client-js/examples/permissioned_keys_example.ts
@@ -8,11 +8,12 @@ import { CompositeClient } from '../src/clients/composite-client';
 import { AuthenticatorType, Network, OrderSide, SelectedGasDenom } from '../src/clients/constants';
 import LocalWallet from '../src/clients/modules/local-wallet';
 import { SubaccountInfo } from '../src/clients/subaccount';
-import { DYDX_TEST_MNEMONIC, DYDX_TEST_MNEMONIC_2 } from './constants';
+import { DYDX_TEST_MNEMONIC, DYDX_TEST_MNEMONIC_2, DYDX_TEST_MNEMONIC_3 } from './constants';
 
 async function test(): Promise<void> {
   const wallet1 = await LocalWallet.fromMnemonic(DYDX_TEST_MNEMONIC, BECH32_PREFIX);
   const wallet2 = await LocalWallet.fromMnemonic(DYDX_TEST_MNEMONIC_2, BECH32_PREFIX);
+  const wallet3 = await LocalWallet.fromMnemonic(DYDX_TEST_MNEMONIC_3, BECH32_PREFIX);
 
   const network = Network.staging();
   const client = await CompositeClient.connect(network);
@@ -23,28 +24,53 @@ async function test(): Promise<void> {
 
   const subaccount1 = new SubaccountInfo(wallet1, 0);
   const subaccount2 = new SubaccountInfo(wallet2, 0);
+  const subaccount3 = new SubaccountInfo(wallet3, 0);
 
   // Change second wallet pubkey
   // Add an authenticator to allow wallet2 to place orders
   console.log("** Adding authenticator **");
-  await addAuthenticator(client, subaccount1, wallet2.pubKey!.value);
+  // Record authenticator count before adding
+  const authsBefore = await client.getAuthenticators(wallet1.address!);
+  const beforeCount = authsBefore.accountAuthenticators.length;
+  console.log(`Authenticators before: ${beforeCount}`);
+  await addTestAuthenticator(client, subaccount1, wallet2.pubKey!.value);
 
-  const authenticators = await client.getAuthenticators(wallet1.address!);
+  console.log("** Waiting 3 seconds for txn to be confirmed **");
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+
+  const authsAfter = await client.getAuthenticators(wallet1.address!);
+  const afterCount = authsAfter.accountAuthenticators.length;
+  console.log(`Authenticators after: ${afterCount}`);
+  if (afterCount !== beforeCount + 1) {
+    console.error('Authenticator count did not increment by 1.');
+    process.exit(1);
+  } else {
+    console.log('Authenticator count incremented by 1 as expected.');
+  }
   // Last element in authenticators array is the most recently created
-  const lastElement = authenticators.accountAuthenticators.length - 1;
-  const authenticatorID = authenticators.accountAuthenticators[lastElement].id;
+  const lastElement = authsAfter.accountAuthenticators.length - 1;
+  const newAuthenticatorID = authsAfter.accountAuthenticators[lastElement].id;
+
+  console.log(`New authenticator ID: ${newAuthenticatorID}`);
 
   // Placing order using subaccount2 for subaccount1 succeeds
-  console.log("** Placing order with authenticator **");
-  await placeOrder(client, subaccount2, subaccount1, authenticatorID);
+  console.log("** Placing order for subaccount1 with subaccount2 + authenticator, should succeed **");
+  await placeOrder(client, subaccount2, subaccount1, newAuthenticatorID);
+
+  // Placing order using subaccount3 for subaccount1 should fail
+  console.log("** Placing order for subaccount1 with subaccount3 + authenticator, should fail **");
+  await placeOrder(client, subaccount3, subaccount1, newAuthenticatorID);
 
   // Remove authenticator
   console.log("** Removing authenticator **");
-  await removeAuthenticator(client, subaccount1, authenticatorID);
+  await removeAuthenticator(client, subaccount1, newAuthenticatorID);
 
+  console.log("** Waiting 3 seconds for txn to be confirmed **");
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+  
   // Placing an order using subaccount2 will now fail
-  console.log("** Placing order with invalid authenticator should fail **");
-  await placeOrder(client, subaccount2, subaccount1, authenticatorID);
+  console.log("** Placing order with removed authenticator should fail **");
+  await placeOrder(client, subaccount2, subaccount1, newAuthenticatorID);
 }
 
 async function removeAuthenticator(
@@ -55,38 +81,41 @@ async function removeAuthenticator(
   await client.removeAuthenticator(subaccount, id);
 }
 
-async function addAuthenticator(
+async function addTestAuthenticator(
   client: CompositeClient,
   subaccount: SubaccountInfo,
   authedPubKey: string,
 ): Promise<void> {
-  const subAuth = [ {
-    type: AuthenticatorType.SIGNATURE_VERIFICATION,
-    config: authedPubKey,
-  },
-  {
-    type: AuthenticatorType.ANY_OF,
-    config: [
+  const msgType = (s: string): string => toBase64(new TextEncoder().encode(s));
+  const anyOfSubAuth = [
     {
       type: AuthenticatorType.MESSAGE_FILTER,
-      config: toBase64(new TextEncoder().encode('/dydxprotocol.clob.MsgPlaceOrder')),
+      config: msgType('/dydxprotocol.clob.MsgPlaceOrder'),
     },
     {
       type: AuthenticatorType.MESSAGE_FILTER,
-      config: toBase64(new TextEncoder().encode('/dydxprotocol.clob.MsgPlaceOrder')),
+      config: msgType('/dydxprotocol.sending.MsgCreateTransfer'),
     },
-    ]
-  }
-];
+  ];
+
+  // Nested AnyOf config must be base64(JSON([...])) as on-chain expects []byte
+  const anyOfConfigB64 = toBase64(new TextEncoder().encode(JSON.stringify(anyOfSubAuth)));
+
+  const subAuth = [
+    {
+      type: AuthenticatorType.SIGNATURE_VERIFICATION,
+      config: authedPubKey,
+    },
+    {
+      type: AuthenticatorType.ANY_OF,
+      config: anyOfConfigB64,
+    },
+  ];
 
   const jsonString = JSON.stringify(subAuth);
   const encodedData = new TextEncoder().encode(jsonString);
 
-  try {
-    await client.addAuthenticator(subaccount, AuthenticatorType.ALL_OF, encodedData);
-  } catch (error) {
-    console.log(error.message);
-  }
+  await client.addAuthenticator(subaccount, AuthenticatorType.ALL_OF, encodedData);
 }
 
 async function placeOrder(

--- a/v4-client-js/src/clients/composite-client.ts
+++ b/v4-client-js/src/clients/composite-client.ts
@@ -1084,7 +1084,7 @@ export class CompositeClient {
           console.log(err);
         });
     });
-    const signature = await this.sign(wallet, () => msgs, true);
+    const signature = await this.sign(subaccount.wallet, () => msgs, true);
 
     return Buffer.from(signature).toString('base64');
   }
@@ -1414,34 +1414,41 @@ export class CompositeClient {
   }
 
   validateAuthenticator(authenticator: Authenticator): boolean {
-    function checkAuthenticator(auth: Authenticator): boolean {
+    const decodeCompositeConfig = (config: unknown): Authenticator[] | null => {
+      if (Array.isArray(config)) {
+        return config as Authenticator[];
+      }
+      if (typeof config === 'string') {
+        try {
+          const decoded = Buffer.from(config, 'base64').toString('utf8');
+          const parsed = JSON.parse(decoded);
+          return Array.isArray(parsed) ? (parsed as Authenticator[]) : null;
+        } catch {
+          return null;
+        }
+      }
+      return null;
+    };
+
+    const checkAuthenticator = (auth: Authenticator): boolean => {
       if (auth.type === AuthenticatorType.SIGNATURE_VERIFICATION) {
-        return true; // A SignatureVerification authenticator is safe.
+        return true;
       }
 
-      if (!Array.isArray(auth.config)) {
-        return false; // Unsafe case: a non-array config for a composite authenticator
+      if (auth.type === AuthenticatorType.ANY_OF || auth.type === AuthenticatorType.ALL_OF) {
+        const subAuthenticators = decodeCompositeConfig(auth.config);
+        if (subAuthenticators == null) {
+          return false;
+        }
+        if (auth.type === AuthenticatorType.ANY_OF) {
+          return subAuthenticators.every((nested) => checkAuthenticator(nested));
+        }
+        return subAuthenticators.some((nested) => checkAuthenticator(nested));
       }
 
-      if (auth.type === AuthenticatorType.ANY_OF) {
-        // ANY_OF is safe only if ALL sub-authenticators return true
-        return auth.config.every((nestedAuth) => checkAuthenticator(nestedAuth));
-      }
-
-      if (auth.type === AuthenticatorType.ALL_OF) {
-        // ALL_OF is safe if at least one sub-authenticator returns true
-        return auth.config.some((nestedAuth) => checkAuthenticator(nestedAuth));
-      }
-
-      // If it's a base-case authenticator but not SignatureVerification, it's unsafe
       return false;
-    }
+    };
 
-    // The top-level authenticator must pass validation
-    if (!checkAuthenticator(authenticator)) {
-      return false;
-    }
-
-    return true;
+    return checkAuthenticator(authenticator);
   }
 }


### PR DESCRIPTION
- Fixes authenticator config encoding/validation for composites. On-chain expects each config as []byte (base64 in JSON), so we now encode nested composite (AnyOf/AllOf) configs as base64(JSON array) before sending. 
- Added a few seconds of wait time in between transactions so earlier txns can be confirmed

Example output:

```
** Adding authenticator **
Authenticators before: 2
** Waiting 3 seconds for txn to be confirmed **
Authenticators after: 3
Authenticator count incremented by 1 as expected.
New authenticator ID: 6
** Placing order for subaccount1 with subaccount2 + authenticator, should succeed **
**Order Tx**
3954072345972227470e0ee6f63f058e45497eaa7622c5110fd63c08e710c0c0
** Placing order for subaccount1 with subaccount3 + authenticator, should fail **
Broadcasting transaction failed: authentication failed for message 0, authenticator id 6, type AllOf: signature verification failed; please verify account number (14156), sequence (11) and chain-id (dydxprotocol-testnet): Signature verification failed: AllOf verification failed
** Removing authenticator **
** Waiting 3 seconds for txn to be confirmed **
** Placing order with removed authenticator should fail **
Broadcasting transaction failed: failed to get initialized authenticator (account = dydx14zzueazeh0hj67cghhf9jypslcf9sh2n5k6art, authenticator id = 6, msg index = 0, msg type url = /dydxprotocol.clob.MsgPlaceOrder): authenticator 6 not found for account dydx14zzueazeh0hj67cghhf9jypslcf9sh2n5k6art: Authenticator is not found
```