### PR TITLE
chore: Bump v4-client-js to 3.6.0

### DIFF
--- a/v4-client-js/package.json
+++ b/v4-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/v4-client-js",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "General client library for the new dYdX system (v4 decentralized)",
   "main": "build/cjs/src/index.js",
   "module": "build/esm/src/index.js",


### PR DESCRIPTION
Bumps to 3.6.0