### PR TITLE
docs: add Nethermind maintenance notice for Python, Rust, and C++ cli…

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@
   </a>
 </div>
 
+## ⚠️ Maintenance Notice
+
+The Python (`v4-client-py-v2`), Rust (`v4-client-rs`), and C++ (`v4-client-cpp`) clients will no longer be maintained by Nethermind after **June 2, 2026**. After that date, these clients will not receive further updates, bug fixes, or support from Nethermind.
+
+Only the TypeScript client (`v4-client-js`), which is maintained by the dYdX team, will continue to receive ongoing support.
+
 ## v4-client-js
 The dYdX Chain Client Typescript client is used for placing transactions and querying the dYdX chain.
 

--- a/v4-client-py-v2/README.md
+++ b/v4-client-py-v2/README.md
@@ -10,6 +10,8 @@
   </a>
 </div>
 
+> ⚠️ **Maintenance Notice:** This Python client will no longer be maintained by Nethermind after **June 2, 2026**. After that date, it will not receive further updates, bug fixes, or support. Only the [TypeScript client (`v4-client-js`)](https://github.com/dydxprotocol/v4-clients/tree/main/v4-client-js), maintained by the dYdX team, will continue to receive ongoing support.
+
 ## Quick links
 
 <div align="center">

--- a/v4-client-rs/README.md
+++ b/v4-client-rs/README.md
@@ -1,5 +1,7 @@
 # Rust client for dYdX v4
 
+> ⚠️ **Maintenance Notice:** This Rust client will no longer be maintained by Nethermind after **June 2, 2026**. After that date, it will not receive further updates, bug fixes, or support. Only the [TypeScript client (`v4-client-js`)](https://github.com/dydxprotocol/v4-clients/tree/main/v4-client-js), maintained by the dYdX team, will continue to receive ongoing support.
+
 The crate implements interaction with the dYdX API.
 
 The following features are implemented:


### PR DESCRIPTION
…ents

Note that the Python, Rust, and C++ clients will no longer be maintained by Nethermind after June 2, 2026. Only the TypeScript client, maintained by the dYdX team, will continue to receive support.